### PR TITLE
Prefer dedicated over integrated GPUs

### DIFF
--- a/info.beyondallreason.bar.desktop
+++ b/info.beyondallreason.bar.desktop
@@ -7,3 +7,4 @@ Icon=info.beyondallreason.bar
 Terminal=false
 Categories=Game;
 Keywords=bar;
+PrefersNonDefaultGPU=true


### PR DESCRIPTION
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

This means that users with laptops don't have to think about which GPU the game runs on; it should now automatically pick the NVidia GPU if a user has an Optimus configuration