### PR TITLE
Update Chobby to 1.1272.0

### DIFF
--- a/info.beyondallreason.bar.appdata.xml
+++ b/info.beyondallreason.bar.appdata.xml
@@ -98,6 +98,11 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="1.1272.0.1" date="2021-11-26">
+            <description>
+                <p>Roll back engine to 582-gddec320 due to desync issues</p>
+            </description>
+        </release>
         <release version="1.1271.0.1" date="2021-11-26">
             <description>
                 <p>Update engine to 653-g954b191</p>

--- a/info.beyondallreason.bar.yml
+++ b/info.beyondallreason.bar.yml
@@ -34,8 +34,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/beyond-all-reason/BYAR-Chobby
-        commit: 567c7e5a8abfb970e4685dc0d4b1b67baf48a9ff
-        tag: v1.1271.0
+        commit: 95208a794d616289d11bbf87f6a5ef20b228a06e
+        tag: v1.1272.0
   - name: spring-launcher
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
roll back engine to 582-gddec320 due to desync issues