### PR TITLE
Reduce the size of package

### DIFF
--- a/info.beyondallreason.bar.yml
+++ b/info.beyondallreason.bar.yml
@@ -25,45 +25,42 @@ finish-args:
   - --share=network
   - --env=PATH=/usr/bin:/app/bin:/usr/lib/sdk/node14/bin
 modules:
-  - name: byar-chobby
-    buildsystem: simple
-    build-commands:
-      - mkdir /app/bar && mkdir /app/bar/BYAR-Chobby
-      - install -Dm644 dist_cfg/build/icon.png /app/share/icons/hicolor/128x128/apps/info.beyondallreason.bar.png
-      - cp -Rp . /app/bar/BYAR-Chobby
-    sources:
-      - type: git
-        url: https://github.com/beyond-all-reason/BYAR-Chobby
-        commit: f7d819dff512d53c0d4cbc8d26bbd55c114cbca0
-        tag: v1.1392.0
   - name: spring-launcher
     buildsystem: simple
     build-commands:
       # Use `--ignore-scripts`, so electron does not make a postinstall request
       - npm ci --offline --ignore-scripts --cache=/run/build/spring-launcher/flatpak-node/npm-cache/
-      - cp -p /app/bar/BYAR-Chobby/dist_cfg/config.json ./src
-      - cp -p /app/bar/BYAR-Chobby/dist_cfg/config-backup.json ./src
-      - cp -p /app/bar/BYAR-Chobby/dist_cfg/springsettings.json ./src
-      - cp -Rp /app/bar/BYAR-Chobby/dist_cfg/renderer/* ./src/renderer
-      - cp -Rp /app/bar/BYAR-Chobby/dist_cfg/files ./files
-      - cp -Rp /app/bar/BYAR-Chobby/dist_cfg/build ./build
+      - cp -p ../BYAR-Chobby/dist_cfg/config.json ./src
+      - cp -p ../BYAR-Chobby/dist_cfg/config-backup.json ./src
+      - cp -p ../BYAR-Chobby/dist_cfg/springsettings.json ./src
+      - cp -Rp ../BYAR-Chobby/dist_cfg/renderer/* ./src/renderer
+      - cp -Rp ../BYAR-Chobby/dist_cfg/files ./files
+      - cp -Rp ../BYAR-Chobby/dist_cfg/build ./build
       - jq '.build.linux.target="dir"' <<<$(<package.json) > package.json
       - cat package.json
-      - . flatpak-node/electron-builder-arch-args.sh
       - |
-        . flatpak-node/electron-builder-arch-args.sh
-        node_modules/.bin/electron-builder -- $ELECTRON_BUILDER_ARCH_ARGS --linux --dir --project /run/build/spring-launcher
+        . ../flatpak-node/electron-builder-arch-args.sh
+        node_modules/.bin/electron-builder -- $ELECTRON_BUILDER_ARCH_ARGS --linux --dir --project /run/build/spring-launcher/launcher
       - cp -a dist/linux*unpacked /app/main
-      - install -Dm755 -t /app/bin/ launcher-args.sh
-      - install -Dm755 -t /app/bin/ run.sh
-      - install -Dm644 info.beyondallreason.bar.desktop /app/share/applications/info.beyondallreason.bar.desktop
-      - install -Dm644 info.beyondallreason.bar.appdata.xml /app/share/metainfo/info.beyondallreason.bar.appdata.xml
+      - install -Dm755 -t /app/bin/ ../launcher-args.sh
+      - install -Dm755 -t /app/bin/ ../run.sh
+      - install -Dm644 ../BYAR-Chobby/dist_cfg/build/icon.png /app/share/icons/hicolor/128x128/apps/info.beyondallreason.bar.png
+      - install -Dm644 ../info.beyondallreason.bar.desktop /app/share/applications/info.beyondallreason.bar.desktop
+      - install -Dm644 ../info.beyondallreason.bar.appdata.xml /app/share/metainfo/info.beyondallreason.bar.appdata.xml
+    subdir: launcher
     sources:
+      - type: git
+        url: https://github.com/beyond-all-reason/BYAR-Chobby
+        commit: f7d819dff512d53c0d4cbc8d26bbd55c114cbca0
+        tag: v1.1392.0
+        dest: BYAR-Chobby
       - type: git
         url: https://github.com/gajop/spring-launcher
         commit: bfa2f59297614f240b1271220a390be5fba00a7c
+        dest: launcher
       - type: patch
         path: patch/remove-launcher-self-update.patch
+        dest: launcher
       - type: file
         path: info.beyondallreason.bar.desktop
       - type: file


### PR DESCRIPTION
This PR refactors how the flatpak package is build to reduce the on disk size from 1GiB to 446MiB (inline with uncompressed AppImage of BAR)

- Don't keep checkout of BYAR-Chobby repository after copying dist_cfg
- Make sure flatpak-node is outside of build directory so it's not included in electron bundle