### PR TITLE
Update launcher to latest version

### DIFF
--- a/info.beyondallreason.bar.yml
+++ b/info.beyondallreason.bar.yml
@@ -55,8 +55,8 @@ modules:
         tag: v1.1487.0
         dest: BYAR-Chobby
       - type: git
-        url: https://github.com/gajop/spring-launcher
-        commit: bfa2f59297614f240b1271220a390be5fba00a7c
+        url: https://github.com/beyond-all-reason/spring-launcher
+        commit: 37aca597a92ed9a9767836f107d780ca5aa2ba8d
         dest: launcher
       - type: patch
         path: patch/remove-launcher-self-update.patch

--- a/launcher-args.sh
+++ b/launcher-args.sh
@@ -1,1 +1,1 @@
-run.sh -w $XDG_DATA_HOME
+run.sh -w $XDG_DATA_HOME "$@"

--- a/patch/remove-launcher-self-update.patch
+++ b/patch/remove-launcher-self-update.patch
@@ -1,6 +1,6 @@
-From d3052a6a60f5e278b887fd59422e4cbc9c775841 Mon Sep 17 00:00:00 2001
+From 3c8803e16cfb592a1256d3b20a2efc0017df73d2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Tobias=20Sch=C3=B6nberg?= <tobias47n9e@gmail.com>
-Date: Thu, 6 Jan 2022 23:16:38 +0100
+Date: Thu, 12 May 2022 21:11:35 +0200
 Subject: [PATCH] Remove launcher self-update
 
 ---
@@ -8,7 +8,7 @@ Subject: [PATCH] Remove launcher self-update
  1 file changed, 17 deletions(-)
 
 diff --git a/src/launcher_wizard.js b/src/launcher_wizard.js
-index c8d67d9..b8597c6 100644
+index 0035d90..b8597c6 100644
 --- a/src/launcher_wizard.js
 +++ b/src/launcher_wizard.js
 @@ -54,23 +54,6 @@ class Wizard extends EventEmitter {
@@ -18,7 +18,7 @@ index c8d67d9..b8597c6 100644
 -			steps.push({
 -				name: 'launcher_update',
 -				action: () => {
--					const isDev = require('electron-is-dev');
+-					const isDev = !require('electron').app.isPackaged;
 -					log.info('Checking for launcher update');
 -					if (!isDev) {
 -						updater.checkForUpdates();
@@ -36,5 +36,5 @@ index c8d67d9..b8597c6 100644
  				steps.push({
  					name: 'engine',
 -- 
-2.32.0
+2.36.1
 


### PR DESCRIPTION
Current version of spring launcher is from January and misses important updates in prd, new electron version etc, this updates it to the latest version used in 1.1487.0 release.