### PR TITLE
Update launcher to the latest version

### DIFF
--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,16 +1,16 @@
 [
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.1.0/SHASUMS256.txt",
-        "sha256": "7a9e6d05d6465b4e4d72477f865a483f6f453695b132e679a531c226a4d146c6",
-        "dest-filename": "SHASUMS256.txt-28.1.0",
+        "url": "https://github.com/electron/electron/releases/download/v29.1.0/SHASUMS256.txt",
+        "sha256": "3652ed027fe76a2912b4640924adc34a4d2043e77d5900a2cd43b913e20135c3",
+        "dest-filename": "SHASUMS256.txt-29.1.0",
         "dest": "flatpak-node/cache/electron"
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.1.0/electron-v28.1.0-linux-arm64.zip",
-        "sha256": "589144d71603bc651e5cb0433fe19e49777e74ec50a57d5a5c0b6dcc9a50d516",
-        "dest-filename": "electron-v28.1.0-linux-arm64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v29.1.0/electron-v29.1.0-linux-arm64.zip",
+        "sha256": "1e6482001dbae554359efee298889d6cd5c8aca18e9e83e91b01da72bf13195d",
+        "dest-filename": "electron-v29.1.0-linux-arm64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "aarch64"
@@ -18,9 +18,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.1.0/electron-v28.1.0-linux-armv7l.zip",
-        "sha256": "ee4cdbac01594fb3592fc4da27cdb8d036227a960704c1906ca5059f417ead98",
-        "dest-filename": "electron-v28.1.0-linux-armv7l.zip",
+        "url": "https://github.com/electron/electron/releases/download/v29.1.0/electron-v29.1.0-linux-armv7l.zip",
+        "sha256": "c6e13bbbecc9e9070dd61e246155fabe04e474596c60fde645d1c245a9ae5d87",
+        "dest-filename": "electron-v29.1.0-linux-armv7l.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "arm"
@@ -28,9 +28,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v28.1.0/electron-v28.1.0-linux-x64.zip",
-        "sha256": "e94f5da5b78015eba5eb3bea4cb4389c0a70fa6c456f5657da2e7d2c3bf8d0b1",
-        "dest-filename": "electron-v28.1.0-linux-x64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v29.1.0/electron-v29.1.0-linux-x64.zip",
+        "sha256": "af7964b3f8c72b5ec1946b46a8396fda67feae71ae0b8bdb329e2abcccf45a81",
+        "dest-filename": "electron-v29.1.0-linux-x64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "x86_64"
@@ -101,10 +101,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@electron/remote/-/remote-2.0.10.tgz",
-        "sha512": "dd214a29a4177325a0c2689bb9df94a8997f5e51ce80b708ddfc2d07da4d7a53d2240713c6870e26b17a15ac412106a3d7e474e438bac6e02cc19a57016ef184",
-        "dest-filename": "4a29a4177325a0c2689bb9df94a8997f5e51ce80b708ddfc2d07da4d7a53d2240713c6870e26b17a15ac412106a3d7e474e438bac6e02cc19a57016ef184",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dd/21"
+        "url": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.2.tgz",
+        "sha512": "10fc0dc7e9e176b4c1c720aa5edfe97eda1083fc9bb560d6dc35161da7de8ef9c1d591867cca6fe9ed790fc29e7a6a687235deefc4fb5ab7b21866f79a567174",
+        "dest-filename": "0dc7e9e176b4c1c720aa5edfe97eda1083fc9bb560d6dc35161da7de8ef9c1d591867cca6fe9ed790fc29e7a6a687235deefc4fb5ab7b21866f79a567174",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/fc"
     },
     {
         "type": "file",
@@ -136,17 +136,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-        "sha512": "80cb157a5f43edfd872e40666bd55bb736517a146881545f6ebfbe7f4ea72f6be708608d973383fbf314a2ffc5e29f26cb2007b291215686e08e95fae2ae66e8",
-        "dest-filename": "157a5f43edfd872e40666bd55bb736517a146881545f6ebfbe7f4ea72f6be708608d973383fbf314a2ffc5e29f26cb2007b291215686e08e95fae2ae66e8",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/cb"
+        "url": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+        "sha512": "62cfb78364da5bb8000ce2733edf37489b420e13239dd703305550fd38fd880d417c9cc5283f660145d3dce7a7a6e3c76c8e8ffe6c840b1449ae87d4b03c7fe6",
+        "dest-filename": "b78364da5bb8000ce2733edf37489b420e13239dd703305550fd38fd880d417c9cc5283f660145d3dce7a7a6e3c76c8e8ffe6c840b1449ae87d4b03c7fe6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/cf"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-        "sha512": "2520433220ca4b34159e07d18ce7455e015f9256972382bd9cb178f40ba1db596605644b20adfec5312b4d60f8294e78a5be9ca0ce84484ec0c33fc5354df381",
-        "dest-filename": "433220ca4b34159e07d18ce7455e015f9256972382bd9cb178f40ba1db596605644b20adfec5312b4d60f8294e78a5be9ca0ce84484ec0c33fc5354df381",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/20"
+        "url": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+        "sha512": "dd3f0b90e9a0e39055e452026f5e5040cb325125ab43c0328157c2ed91b7db339a967aab8a59b4d7c6550b0d1e6a95eec7c16d037deaf0f4914acb6379ede34a",
+        "dest-filename": "0b90e9a0e39055e452026f5e5040cb325125ab43c0328157c2ed91b7db339a967aab8a59b4d7c6550b0d1e6a95eec7c16d037deaf0f4914acb6379ede34a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dd/3f"
     },
     {
         "type": "file",
@@ -157,227 +157,234 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-        "sha512": "76fb82797e5f0bd7578099fdb7e5f96ad7e681003350e5aa4b5db9e068749ba8bcc0a775d1e6d791f34a8912bed465a2ff24efbcb0c7a68c4baf4c71c5eb255b",
-        "dest-filename": "82797e5f0bd7578099fdb7e5f96ad7e681003350e5aa4b5db9e068749ba8bcc0a775d1e6d791f34a8912bed465a2ff24efbcb0c7a68c4baf4c71c5eb255b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/fb"
+        "url": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+        "sha512": "e84c224a3c1660fee94dc906e88e5ec8500d8cf8663e3517f4944b5127cd3c2ec55fbccaf60c9901f50468408be802d3a465f90239c1ab70bd5e65563e2b4da7",
+        "dest-filename": "224a3c1660fee94dc906e88e5ec8500d8cf8663e3517f4944b5127cd3c2ec55fbccaf60c9901f50468408be802d3a465f90239c1ab70bd5e65563e2b4da7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/4c"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.10.tgz",
-        "sha512": "d545d1975370d4aa6d675af400daad5ceb2df6f187e7576aee4795290cf2c933b6973e1d39a7b34bd4adb924cd87e46688783f4953da151a4f7c1d12fe59f82a",
-        "dest-filename": "d1975370d4aa6d675af400daad5ceb2df6f187e7576aee4795290cf2c933b6973e1d39a7b34bd4adb924cd87e46688783f4953da151a4f7c1d12fe59f82a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/45"
+        "url": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+        "sha512": "3bc8dc8da6d76a578e1bd0d0d3e0115d66414df9cfe16340ab3ba224aee5978e009b118abff2763384cf8f18d8df39c109fbc15c5cee726d6dc1dc85c9b16a10",
+        "dest-filename": "dc8da6d76a578e1bd0d0d3e0115d66414df9cfe16340ab3ba224aee5978e009b118abff2763384cf8f18d8df39c109fbc15c5cee726d6dc1dc85c9b16a10",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/c8"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/core/-/core-0.22.10.tgz",
-        "sha512": "64acab7a1572eb0bb53e7057214a67fdf5e6c8c45089549bbc70ee6e05f3e1b7d339aa371a23aeaca1e3072bad408828cee00de991d689281ed5d280f9d7b1df",
-        "dest-filename": "ab7a1572eb0bb53e7057214a67fdf5e6c8c45089549bbc70ee6e05f3e1b7d339aa371a23aeaca1e3072bad408828cee00de991d689281ed5d280f9d7b1df",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/ac"
+        "url": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.12.tgz",
+        "sha512": "69e23ae070f49e9ae8a5df8047be8c09cbef45a6be41c93a96808e4b4dc2924c461cde7faf7dfaa933391cf51d1ca303386cea927b953c0f3e90ad6dd37cf5da",
+        "dest-filename": "3ae070f49e9ae8a5df8047be8c09cbef45a6be41c93a96808e4b4dc2924c461cde7faf7dfaa933391cf51d1ca303386cea927b953c0f3e90ad6dd37cf5da",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/69/e2"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.10.tgz",
-        "sha512": "b0f6645187b586ed22220362b238b3c4f26aab6bda68abe40a43e85ead94e94577640d6c8bf59576b836e5d6b721c188115fbcdc0a0780cf13bea94b82b089b2",
-        "dest-filename": "645187b586ed22220362b238b3c4f26aab6bda68abe40a43e85ead94e94577640d6c8bf59576b836e5d6b721c188115fbcdc0a0780cf13bea94b82b089b2",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/f6"
+        "url": "https://registry.npmjs.org/@jimp/core/-/core-0.22.12.tgz",
+        "sha512": "974451d1d38fcb330a7e3516d6e79bcee785103b423a3f5f37aa724d859638cfd54b805c897435555ac9b3ca4ede4c9c1986719dc44a842a3281b36bf1e11940",
+        "dest-filename": "51d1d38fcb330a7e3516d6e79bcee785103b423a3f5f37aa724d859638cfd54b805c897435555ac9b3ca4ede4c9c1986719dc44a842a3281b36bf1e11940",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/44"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/gif/-/gif-0.22.10.tgz",
-        "sha512": "c845f6752a5a9af912c753cf0d61a729e583ac1cf4beb08a8d51bf727e19afaf0c4514fbe6d6d921e3ab05af91894a58de1a398b1edddfa2e462fb77a9f50885",
-        "dest-filename": "f6752a5a9af912c753cf0d61a729e583ac1cf4beb08a8d51bf727e19afaf0c4514fbe6d6d921e3ab05af91894a58de1a398b1edddfa2e462fb77a9f50885",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/45"
+        "url": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
+        "sha512": "c5c9b0c353bf2453f632b94650c77743bf12dd0bba5b79984d762e22a16adf7128ae060757f1eaca61df5f2f468e2089ece23eee55b1ea76053b353b338addd5",
+        "dest-filename": "b0c353bf2453f632b94650c77743bf12dd0bba5b79984d762e22a16adf7128ae060757f1eaca61df5f2f468e2089ece23eee55b1ea76053b353b338addd5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/c9"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.10.tgz",
-        "sha512": "e9bbbdf2901c54de03636a220cb0b84ce822797fe566b2ddd6da266d664e1423793c19aa6874319bb214993f968f87da12f87c4121e054b480fb625041125654",
-        "dest-filename": "bdf2901c54de03636a220cb0b84ce822797fe566b2ddd6da266d664e1423793c19aa6874319bb214993f968f87da12f87c4121e054b480fb625041125654",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/bb"
+        "url": "https://registry.npmjs.org/@jimp/gif/-/gif-0.22.12.tgz",
+        "sha512": "cba0454c981c87d99ba2bd87db7e154a377d8b002168d7ffb77512e6aa5822cd1349b02f334d856dcdbc21a0c44e3f7ee18078ebbeaccf845c37fcf085fbb5a6",
+        "dest-filename": "454c981c87d99ba2bd87db7e154a377d8b002168d7ffb77512e6aa5822cd1349b02f334d856dcdbc21a0c44e3f7ee18078ebbeaccf845c37fcf085fbb5a6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cb/a0"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.10.tgz",
-        "sha512": "e8423c4a5fa6c581c4232e98b5e87a7a49c3f84660b8aa4d76bdec08ac4d7b398b474faf2bdf6f1dc965a3ab864a35d78b0b704baed7ab19fc4aca1ab4bf9425",
-        "dest-filename": "3c4a5fa6c581c4232e98b5e87a7a49c3f84660b8aa4d76bdec08ac4d7b398b474faf2bdf6f1dc965a3ab864a35d78b0b704baed7ab19fc4aca1ab4bf9425",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/42"
+        "url": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.12.tgz",
+        "sha512": "46adba5c2fee4166902b26ffe6592c0930b15e1b58d3534978137e750bf9c8d61e74dd22ee262ef9f5c4a11b1f689f316738e800d1fcb27b3bad53f8184eddfd",
+        "dest-filename": "ba5c2fee4166902b26ffe6592c0930b15e1b58d3534978137e750bf9c8d61e74dd22ee262ef9f5c4a11b1f689f316738e800d1fcb27b3bad53f8184eddfd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/ad"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.10.tgz",
-        "sha512": "e174535ae3d574c5c979c949322b173c68b3787b53af255a555e479ee417a4aa8866dcd745e082a4d187f2afe2d24050390317846592de6a6a384c2da4f78f2b",
-        "dest-filename": "535ae3d574c5c979c949322b173c68b3787b53af255a555e479ee417a4aa8866dcd745e082a4d187f2afe2d24050390317846592de6a6a384c2da4f78f2b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e1/74"
+        "url": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
+        "sha512": "c6c973d99a0564e3cb63c119e1d0b6f66d7af01b43c7de43e8af344f38148bc82a4fb2d8e82b1a8d63b4140c43c07cfa8747a898731fc865f4b2db2906b4ca9d",
+        "dest-filename": "73d99a0564e3cb63c119e1d0b6f66d7af01b43c7de43e8af344f38148bc82a4fb2d8e82b1a8d63b4140c43c07cfa8747a898731fc865f4b2db2906b4ca9d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c6/c9"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.22.10.tgz",
-        "sha512": "9a17304ced72c11c620a0b4b1a07bab430c80cf957eaa908dc263e0638061bf5e154771c09d75780e18b7657fee4eb8a20417636ab34574d4b4044082454e613",
-        "dest-filename": "304ced72c11c620a0b4b1a07bab430c80cf957eaa908dc263e0638061bf5e154771c09d75780e18b7657fee4eb8a20417636ab34574d4b4044082454e613",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/17"
+        "url": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.12.tgz",
+        "sha512": "4b4bc90034ee87543d17e71703014f96b296cc38f617db7ff4901b52f69a0ee8afa725ae22610a5d5cf93d4670d8d6e9b921e3c2cb1b4e9399f05d778895f8bb",
+        "dest-filename": "c90034ee87543d17e71703014f96b296cc38f617db7ff4901b52f69a0ee8afa725ae22610a5d5cf93d4670d8d6e9b921e3c2cb1b4e9399f05d778895f8bb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/4b"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.10.tgz",
-        "sha512": "7b8b772fb29e75df7a134c755e3b1333a35c82e94a514eba1dd1536a8ed373d15825115296db40459fc2e8b12bc860e6fe2ebd47a6c9129a3b064373d182f9e5",
-        "dest-filename": "772fb29e75df7a134c755e3b1333a35c82e94a514eba1dd1536a8ed373d15825115296db40459fc2e8b12bc860e6fe2ebd47a6c9129a3b064373d182f9e5",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/8b"
+        "url": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.22.12.tgz",
+        "sha512": "496557c75ca2ba3e6366d3228ea51fbd53890703a27c59f4f75f28bb87eda0781e81ce5a1d65b97596d83e3bc2f5f2e9bf3ee84a5a6d365d92c6bd73c287e34e",
+        "dest-filename": "57c75ca2ba3e6366d3228ea51fbd53890703a27c59f4f75f28bb87eda0781e81ce5a1d65b97596d83e3bc2f5f2e9bf3ee84a5a6d365d92c6bd73c287e34e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/65"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.22.10.tgz",
-        "sha512": "78ff0aaf372db84a2a89b400c62f5685b9e8468b327618b083e218c9addd2ae283053ac3f541edf844653d0fe54cd587cd5fe5e12d67b55debf6cf6c68982c5c",
-        "dest-filename": "0aaf372db84a2a89b400c62f5685b9e8468b327618b083e218c9addd2ae283053ac3f541edf844653d0fe54cd587cd5fe5e12d67b55debf6cf6c68982c5c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/78/ff"
+        "url": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
+        "sha512": "c489a14c4e41a52f316be98037a8f8b0c4566948140cba1a1878498690beafb48a284ad80d1d16415e32084e203fe374828cc3d05dca6b52d449a317ae7ed920",
+        "dest-filename": "a14c4e41a52f316be98037a8f8b0c4566948140cba1a1878498690beafb48a284ad80d1d16415e32084e203fe374828cc3d05dca6b52d449a317ae7ed920",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/89"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.22.10.tgz",
-        "sha512": "9090b02f94f58a07dad089c27e413b6c17aa836ea6e3a6a846dd74ba0fabbe6d753fa46bbd1306ae020d17220a07e9a707b0a2c8137f30eba56b50af2e14889d",
-        "dest-filename": "b02f94f58a07dad089c27e413b6c17aa836ea6e3a6a846dd74ba0fabbe6d753fa46bbd1306ae020d17220a07e9a707b0a2c8137f30eba56b50af2e14889d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/90"
+        "url": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.22.12.tgz",
+        "sha512": "128dc399f8b1270dcdefd95693cabfd120d86ea98ab75c524c9ebdcb2f172d8423f6cbe805bc91a529c747e9fd84ec39a4a5f2b47c145ba9d4e2ed707a01cda1",
+        "dest-filename": "c399f8b1270dcdefd95693cabfd120d86ea98ab75c524c9ebdcb2f172d8423f6cbe805bc91a529c747e9fd84ec39a4a5f2b47c145ba9d4e2ed707a01cda1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/8d"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.10.tgz",
-        "sha512": "04e67e60669996153b739c9eeb94718a489c5c7d0a8b422debf5c7212be2a51e5666b7e32e32f629edb41be0069f005073bea029e9d570c5d55029c48ed655f9",
-        "dest-filename": "7e60669996153b739c9eeb94718a489c5c7d0a8b422debf5c7212be2a51e5666b7e32e32f629edb41be0069f005073bea029e9d570c5d55029c48ed655f9",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/e6"
+        "url": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.22.12.tgz",
+        "sha512": "cf4c3fd711ffbff927664a53371f84f1aedf9dab10db01c6e737bacb9a0bd9d847d54b9f36e6bc80b41796ff3f5b9ebee272756eb852776df71c1242a34d415c",
+        "dest-filename": "3fd711ffbff927664a53371f84f1aedf9dab10db01c6e737bacb9a0bd9d847d54b9f36e6bc80b41796ff3f5b9ebee272756eb852776df71c1242a34d415c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/4c"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.22.10.tgz",
-        "sha512": "9653625963132884835ede7e71723419a166656023953fb87c52d87f8797aaeb8bffdc19a10b04061bf619d19de3c9a4892f2366ad4d9dbd90e1e8443d3bebcf",
-        "dest-filename": "625963132884835ede7e71723419a166656023953fb87c52d87f8797aaeb8bffdc19a10b04061bf619d19de3c9a4892f2366ad4d9dbd90e1e8443d3bebcf",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/53"
+        "url": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
+        "sha512": "14db94374395cd10a8cf1f174a03fd3322c63313471c9305b7e2c9b858e7d66bb7934550c6bcea6cdd3ac88978e9355e8e1c8085cab980bcea992087be570157",
+        "dest-filename": "94374395cd10a8cf1f174a03fd3322c63313471c9305b7e2c9b858e7d66bb7934550c6bcea6cdd3ac88978e9355e8e1c8085cab980bcea992087be570157",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/db"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.22.10.tgz",
-        "sha512": "d3958b99e57933e3ffd054be6d67f5de131ec365f4a1af30f40b667af2f653203fe46aa2caf3f65e6e567c643ca058a232fa672fa445a26250399b5671ad02db",
-        "dest-filename": "8b99e57933e3ffd054be6d67f5de131ec365f4a1af30f40b667af2f653203fe46aa2caf3f65e6e567c643ca058a232fa672fa445a26250399b5671ad02db",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/95"
+        "url": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.22.12.tgz",
+        "sha512": "aa944cf094627317cae9a3cfa8a640ebe1b30705088ad887699c3442b27ae1881ddfe02c4dcec15ebfb7ee4db1ed07320af98a5d8e21694ad222c06e8384b708",
+        "dest-filename": "4cf094627317cae9a3cfa8a640ebe1b30705088ad887699c3442b27ae1881ddfe02c4dcec15ebfb7ee4db1ed07320af98a5d8e21694ad222c06e8384b708",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/94"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.22.10.tgz",
-        "sha512": "2278e25ef73b1a4cebc7c556b54f7b903a95ec436784718f50bca6256799685d9a89cb9df45a64e220ad77f0dc648ae4ec26deeb403c470357374d075c86d20a",
-        "dest-filename": "e25ef73b1a4cebc7c556b54f7b903a95ec436784718f50bca6256799685d9a89cb9df45a64e220ad77f0dc648ae4ec26deeb403c470357374d075c86d20a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/22/78"
+        "url": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.22.12.tgz",
+        "sha512": "8d88067527522a5d545046a75fc03ce6fe3e4149be3c4f2f1c5c256a668a93cf6cf8f5d07bb79513778d792657e229c2abadc41cbedc5f9f3474caa4a02dd92f",
+        "dest-filename": "067527522a5d545046a75fc03ce6fe3e4149be3c4f2f1c5c256a668a93cf6cf8f5d07bb79513778d792657e229c2abadc41cbedc5f9f3474caa4a02dd92f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8d/88"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.22.10.tgz",
-        "sha512": "e361a41ad4c75a7867c1330f54afe45ce6d96e4608a5059fb887f2e44304324eb3463d39ce9bf8bec8e42967ee7a6c1e6483707ef0fbc03245ec554534d71966",
-        "dest-filename": "a41ad4c75a7867c1330f54afe45ce6d96e4608a5059fb887f2e44304324eb3463d39ce9bf8bec8e42967ee7a6c1e6483707ef0fbc03245ec554534d71966",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/61"
+        "url": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.22.12.tgz",
+        "sha512": "2c6b944ec160f9f3a9e8a04aae62e45f82dfc82cbc208b113b0a14bec50f2b3bad4aa3099ec9b72460d6d9e3a65884bf8c9a4f69e6a2b218e5c6f7338e0208f9",
+        "dest-filename": "944ec160f9f3a9e8a04aae62e45f82dfc82cbc208b113b0a14bec50f2b3bad4aa3099ec9b72460d6d9e3a65884bf8c9a4f69e6a2b218e5c6f7338e0208f9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/6b"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.22.10.tgz",
-        "sha512": "ca4ac6ffa953a7d439600f234b95f3c0c1ed4716fd1ce14c82d9a7ad467c914f812bc44479c7f2f4873905410e8c262f4b56bfc4bb27ad9414d3b8a263107116",
-        "dest-filename": "c6ffa953a7d439600f234b95f3c0c1ed4716fd1ce14c82d9a7ad467c914f812bc44479c7f2f4873905410e8c262f4b56bfc4bb27ad9414d3b8a263107116",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/4a"
+        "url": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.22.12.tgz",
+        "sha512": "9b6e75468a7b18df16d18a3fac5f4b5a4ea435c9678328c826cfd55c74e8190e841af78e493490697d88b22f5ff650832f1b7e8a70486fb9e568b2f19ef1d7f1",
+        "dest-filename": "75468a7b18df16d18a3fac5f4b5a4ea435c9678328c826cfd55c74e8190e841af78e493490697d88b22f5ff650832f1b7e8a70486fb9e568b2f19ef1d7f1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/6e"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.22.10.tgz",
-        "sha512": "77c8fd06550962cfdcf7de2de1acd45925a642ae0b2cf1b879c9bc9ba49236a6a9f92fc7955406aa362124405b63d11790e4d807dbc12fd6eac1233546bea968",
-        "dest-filename": "fd06550962cfdcf7de2de1acd45925a642ae0b2cf1b879c9bc9ba49236a6a9f92fc7955406aa362124405b63d11790e4d807dbc12fd6eac1233546bea968",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/77/c8"
+        "url": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.22.12.tgz",
+        "sha512": "b017dbce83a627a15ccdf1b63eaba22bce0db5519e49cc3dec9b020b7ae942fd4f1d55b25bebaa585179dfe9f773c6343f61d69548df94495ada1fef59286f86",
+        "dest-filename": "dbce83a627a15ccdf1b63eaba22bce0db5519e49cc3dec9b020b7ae942fd4f1d55b25bebaa585179dfe9f773c6343f61d69548df94495ada1fef59286f86",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/17"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.22.10.tgz",
-        "sha512": "c9106cd76df45d9933db8b854dd4dc4a56741d7669216cccde2150379e8ccd9ed44a07556633cf0c243c23d469a9f677ea70df9509143b4c15eee72c8b8a20a3",
-        "dest-filename": "6cd76df45d9933db8b854dd4dc4a56741d7669216cccde2150379e8ccd9ed44a07556633cf0c243c23d469a9f677ea70df9509143b4c15eee72c8b8a20a3",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/10"
+        "url": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.22.12.tgz",
+        "sha512": "37eeabc31741fbb38247a3d88a3680fe28b35d7a1da71386bd3fec99dfe5c5e5ec67f7a6a4798514527f15a5dc621d7d4e6d387460da5dc345fdd3799e6ebec5",
+        "dest-filename": "abc31741fbb38247a3d88a3680fe28b35d7a1da71386bd3fec99dfe5c5e5ec67f7a6a4798514527f15a5dc621d7d4e6d387460da5dc345fdd3799e6ebec5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/ee"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.22.10.tgz",
-        "sha512": "5a4f465fa78931c857fd901acd56bbd056a0bbe39732f1e23d8f87adc13071c94bfa9d70a3cc401c4b1ff622a7a3b25ae0453d94b85b05163985827288a30492",
-        "dest-filename": "465fa78931c857fd901acd56bbd056a0bbe39732f1e23d8f87adc13071c94bfa9d70a3cc401c4b1ff622a7a3b25ae0453d94b85b05163985827288a30492",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/4f"
+        "url": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.22.12.tgz",
+        "sha512": "e0059983e0e89ada54034f7d8d157c2046547e7d702efebe9de9b8351242ecbffcdafc732c2817293c6f36f05c3662634fdc92d4b0009a22467562971badff34",
+        "dest-filename": "9983e0e89ada54034f7d8d157c2046547e7d702efebe9de9b8351242ecbffcdafc732c2817293c6f36f05c3662634fdc92d4b0009a22467562971badff34",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/05"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.22.10.tgz",
-        "sha512": "d54dd5968211f9b784d6458f7461093221368750e8dbd8afdf0f2c05bbcfc913f8a97c5115c0e99821ad72db2b2a66f592b9411658fcb9bc8063dd312fee67f7",
-        "dest-filename": "d5968211f9b784d6458f7461093221368750e8dbd8afdf0f2c05bbcfc913f8a97c5115c0e99821ad72db2b2a66f592b9411658fcb9bc8063dd312fee67f7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/4d"
+        "url": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.22.12.tgz",
+        "sha512": "d12a34adec508af9d682785a717e1c7e4336db6dd8744c672534f2e9dd3a59b91f664e5a947531f0c337c84cf0a0237412b3bba32a845919c49060be02cd45b4",
+        "dest-filename": "34adec508af9d682785a717e1c7e4336db6dd8744c672534f2e9dd3a59b91f664e5a947531f0c337c84cf0a0237412b3bba32a845919c49060be02cd45b4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d1/2a"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.10.tgz",
-        "sha512": "8b1a26c5572700e3570e06aad28a6f031e1400e88484e03fb62a6e84514ebcf285778c9fd4102712f881e66681d120471e42573d44b30e9ffbdf155330649eee",
-        "dest-filename": "26c5572700e3570e06aad28a6f031e1400e88484e03fb62a6e84514ebcf285778c9fd4102712f881e66681d120471e42573d44b30e9ffbdf155330649eee",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8b/1a"
+        "url": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.22.12.tgz",
+        "sha512": "73b4e78479719bcec325e4a7c2bfd738b8c953fc21a2229863baf6d526ee2799ee1feedaefc116d6d78e6a3e6012bdb060477b42d905a86966c865d8fd8725c9",
+        "dest-filename": "e78479719bcec325e4a7c2bfd738b8c953fc21a2229863baf6d526ee2799ee1feedaefc116d6d78e6a3e6012bdb060477b42d905a86966c865d8fd8725c9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/b4"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.10.tgz",
-        "sha512": "79e157f1d9d1c9fdcb01db1d5d6296b8dd7c84b460f33cb570fd1c3fdac7cd055644aedc93f42c2f12b5bc7abb3000c6c106a535a35327d490c47e9cf26cfa8f",
-        "dest-filename": "57f1d9d1c9fdcb01db1d5d6296b8dd7c84b460f33cb570fd1c3fdac7cd055644aedc93f42c2f12b5bc7abb3000c6c106a535a35327d490c47e9cf26cfa8f",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/e1"
+        "url": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
+        "sha512": "dcdc933e53db4e718a0c86da0604371db13ac176c09457f11d51119ab6ea022f11debe9f40fc6909ab80f145439e27a0e5ea34e03d13f279e73485fffe2fec5e",
+        "dest-filename": "933e53db4e718a0c86da0604371db13ac176c09457f11d51119ab6ea022f11debe9f40fc6909ab80f145439e27a0e5ea34e03d13f279e73485fffe2fec5e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/dc"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.10.tgz",
-        "sha512": "4c6fc7d2850debd0bd02b042660e0f9aea22c4554a222aeef36f362b3481fd3a75234c705f45cb4efddd279a686cf94880f701f93983e31008764093e2bb56c6",
-        "dest-filename": "c7d2850debd0bd02b042660e0f9aea22c4554a222aeef36f362b3481fd3a75234c705f45cb4efddd279a686cf94880f701f93983e31008764093e2bb56c6",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4c/6f"
+        "url": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
+        "sha512": "f58344b7b04f0057d396cd8519f281560c302d4b8aab2f84f1b0c6184b0ea87b5bba16ec8551b137658c65a0f8821e480d6bd1f9e9a698f3d61a0698358b7580",
+        "dest-filename": "44b7b04f0057d396cd8519f281560c302d4b8aab2f84f1b0c6184b0ea87b5bba16ec8551b137658c65a0f8821e480d6bd1f9e9a698f3d61a0698358b7580",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/83"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.22.10.tgz",
-        "sha512": "4cdf719ba7c8ed77f16cc510a853d98efe7d5dda5fd2d4a2010748341e20ea924c5a2540351ffbe0eb4338da32dca2a97a7bb9637f2cf8592bb480ff29c40087",
-        "dest-filename": "719ba7c8ed77f16cc510a853d98efe7d5dda5fd2d4a2010748341e20ea924c5a2540351ffbe0eb4338da32dca2a97a7bb9637f2cf8592bb480ff29c40087",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4c/df"
+        "url": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
+        "sha512": "76086cf76a8ce8c8478f41eb576a80c0a3cc92542d8cda68620001f78cac629b17b258514e23e2b2e7922042d1c19184af4274554c69518ec7809c2548880667",
+        "dest-filename": "6cf76a8ce8c8478f41eb576a80c0a3cc92542d8cda68620001f78cac629b17b258514e23e2b2e7922042d1c19184af4274554c69518ec7809c2548880667",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/08"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.22.10.tgz",
-        "sha512": "0c0da54a75344e02116c08265dac6ba18c3701de89d83385128269d0d95e4a6da1dc659b644139c96f54d81ea10f78aa9f801e9c6e04d9bd96cc75d9cb34aeb7",
-        "dest-filename": "a54a75344e02116c08265dac6ba18c3701de89d83385128269d0d95e4a6da1dc659b644139c96f54d81ea10f78aa9f801e9c6e04d9bd96cc75d9cb34aeb7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0c/0d"
+        "url": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.22.12.tgz",
+        "sha512": "157f264c9b82b7bff7cd7568783fea1e59b8607d9b56a06e5901d74ae04ad39e1eef01519d19db48b3d4a80c127983f7956aa9b90cc9b608a2071577f965b04e",
+        "dest-filename": "264c9b82b7bff7cd7568783fea1e59b8607d9b56a06e5901d74ae04ad39e1eef01519d19db48b3d4a80c127983f7956aa9b90cc9b608a2071577f965b04e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/7f"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.22.10.tgz",
-        "sha512": "283319c8cea99af4bc7eb781f9404b928d533bf9380fb5114bf9e9842a33b87f8fee2dd431eecd75c917289f2ef960fab2a37460562f05e8699299d48b0ffdd7",
-        "dest-filename": "19c8cea99af4bc7eb781f9404b928d533bf9380fb5114bf9e9842a33b87f8fee2dd431eecd75c917289f2ef960fab2a37460562f05e8699299d48b0ffdd7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/28/33"
+        "url": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.22.12.tgz",
+        "sha512": "e31e46ad0af56bff4bd296810bf3196498e3823c4b62ba9299677e7be41f0043ef991c5d468439b8a12e3605e79bdff07874014e740142c398da21636be5c603",
+        "dest-filename": "46ad0af56bff4bd296810bf3196498e3823c4b62ba9299677e7be41f0043ef991c5d468439b8a12e3605e79bdff07874014e740142c398da21636be5c603",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/1e"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/png/-/png-0.22.10.tgz",
-        "sha512": "4588a753bb594e879e476836a80327e36014fbc3941e35cf29967d4649a82f86e0b80d71c9959a49daf6dbf1419269c784e111465af4d8a3c33753933981cb0d",
-        "dest-filename": "a753bb594e879e476836a80327e36014fbc3941e35cf29967d4649a82f86e0b80d71c9959a49daf6dbf1419269c784e111465af4d8a3c33753933981cb0d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/88"
+        "url": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.22.12.tgz",
+        "sha512": "c8127cbd0ac39016d381064bb72f64e3e2ad5107518ec2032523e3b88db561d55ea99c58cb089f1e5e3f5d620ba1366c8d3500490706a07d13b82d0def19b7c3",
+        "dest-filename": "7cbd0ac39016d381064bb72f64e3e2ad5107518ec2032523e3b88db561d55ea99c58cb089f1e5e3f5d620ba1366c8d3500490706a07d13b82d0def19b7c3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/12"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.10.tgz",
-        "sha512": "39a8af952633a4d4c7c87fe1ee912d97703b17b4dbb20cad66ce7618b5ffc484d6f767df803813e8f925748accac44fa11187f85d8a335089ec3b228104af6a2",
-        "dest-filename": "af952633a4d4c7c87fe1ee912d97703b17b4dbb20cad66ce7618b5ffc484d6f767df803813e8f925748accac44fa11187f85d8a335089ec3b228104af6a2",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/a8"
+        "url": "https://registry.npmjs.org/@jimp/png/-/png-0.22.12.tgz",
+        "sha512": "32ba7a76bdd44e7f9a2caf2dcbf7522842f3f8eb5dcf5bf86805f3579ab9dd40c3dab6c1e63a0a549fc2858df5d01f9e473371228bdb505d4a56b52c61d13c1e",
+        "dest-filename": "7a76bdd44e7f9a2caf2dcbf7522842f3f8eb5dcf5bf86805f3579ab9dd40c3dab6c1e63a0a549fc2858df5d01f9e473371228bdb505d4a56b52c61d13c1e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/ba"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/types/-/types-0.22.10.tgz",
-        "sha512": "bbfafe5d8cdb0b1e3366e9039b1c7c4b47abdd8ab78833c8ebedf558a5f4375f22daa3cf258727f2ac0816eadfba946e986bc9f129462c282dfd3f98f33cd423",
-        "dest-filename": "fe5d8cdb0b1e3366e9039b1c7c4b47abdd8ab78833c8ebedf558a5f4375f22daa3cf258727f2ac0816eadfba946e986bc9f129462c282dfd3f98f33cd423",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/fa"
+        "url": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.12.tgz",
+        "sha512": "1352ed321e11c89b280807c0901455498c990d3b4babda7d2d48a260fd2f3ed5f2c57e018980546228532d20650908399c5d9ee0ea5083b48facb749ebabbb8e",
+        "dest-filename": "ed321e11c89b280807c0901455498c990d3b4babda7d2d48a260fd2f3ed5f2c57e018980546228532d20650908399c5d9ee0ea5083b48facb749ebabbb8e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/52"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@jimp/utils/-/utils-0.22.10.tgz",
-        "sha512": "ced94e2bd326da22c6d8032869bccce22dd667f16db21720b0909b642454b3f0caa1e4b6b724912539d06756fb468ab433809ef85500c67080701574abb3c7f7",
-        "dest-filename": "4e2bd326da22c6d8032869bccce22dd667f16db21720b0909b642454b3f0caa1e4b6b724912539d06756fb468ab433809ef85500c67080701574abb3c7f7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ce/d9"
+        "url": "https://registry.npmjs.org/@jimp/types/-/types-0.22.12.tgz",
+        "sha512": "c30298cd1744944d4c05715112f0ada39b3af7d8b3147355bc02d4bfbf465cd6ec395aa5c253b195627c0eec8e1885e82cfe095bf9b7d18cae4ed7d426031130",
+        "dest-filename": "98cd1744944d4c05715112f0ada39b3af7d8b3147355bc02d4bfbf465cd6ec395aa5c253b195627c0eec8e1885e82cfe095bf9b7d18cae4ed7d426031130",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c3/02"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jimp/utils/-/utils-0.22.12.tgz",
+        "sha512": "c89e5c5949271a78a506af7b6573b2392d0786c1cec80ca31f061f1f119b4b2313a2181023ab15c84f0a3e00f01fc1c75bf9cc29793c4eb4b0004ef5cedef5e9",
+        "dest-filename": "5c5949271a78a506af7b6573b2392d0786c1cec80ca31f061f1f119b4b2313a2181023ab15c84f0a3e00f01fc1c75bf9cc29793c4eb4b0004ef5cedef5e9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/9e"
     },
     {
         "type": "file",
@@ -413,6 +420,13 @@
         "sha512": "a0607e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a",
         "dest-filename": "7e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/60"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+        "sha512": "fb55648dd0f44012cfa1d1ab2547aa6ab1fc54022f40e0c86f087d5e93f94b28ac7fb628420b0928f345a2aa8b425bbe550fed552b21311ea5a0f327f14f9d3e",
+        "dest-filename": "648dd0f44012cfa1d1ab2547aa6ab1fc54022f40e0c86f087d5e93f94b28ac7fb628420b0928f345a2aa8b425bbe550fed552b21311ea5a0f327f14f9d3e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/55"
     },
     {
         "type": "file",
@@ -493,10 +507,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
-        "sha512": "9397e082bd780f0032b6803fb7cacfac8cfefa55caeff0ea724b610a6a1938a36c11b26421de19fff06a800a570541ab19d76b8a061ad68aa17a8ffb6265b8ae",
-        "dest-filename": "e082bd780f0032b6803fb7cacfac8cfefa55caeff0ea724b610a6a1938a36c11b26421de19fff06a800a570541ab19d76b8a061ad68aa17a8ffb6265b8ae",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/97"
+        "url": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+        "sha512": "2b36b8ddec12df1a0b80212942bb13fb1468fc425e8f5cb491560688b144d4d10e0d71b34dfc220bab574cb310b249f55f8fd18e587431052fc7d5be2fd9689e",
+        "dest-filename": "b8ddec12df1a0b80212942bb13fb1468fc425e8f5cb491560688b144d4d10e0d71b34dfc220bab574cb310b249f55f8fd18e587431052fc7d5be2fd9689e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2b/36"
     },
     {
         "type": "file",
@@ -549,10 +563,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-        "sha512": "9dcd00c73a7fd0520b2c456c9b87cdc0b0b032db6f844236eb742d54f41c6e97d9677b6cd212ec6463a913a73336589dec227d325c87f2b797929b1fdd8518e3",
-        "dest-filename": "00c73a7fd0520b2c456c9b87cdc0b0b032db6f844236eb742d54f41c6e97d9677b6cd212ec6463a913a73336589dec227d325c87f2b797929b1fdd8518e3",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9d/cd"
+        "url": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+        "sha512": "63dad17c91b98dc28e13408b8ac61ba2352322b20413b00633303f4a6e01b2500d85b4be70332980175c3d3f75a09eceb89f61609071e7d4636e1c559eb17c5e",
+        "dest-filename": "d17c91b98dc28e13408b8ac61ba2352322b20413b00633303f4a6e01b2500d85b4be70332980175c3d3f75a09eceb89f61609071e7d4636e1c559eb17c5e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/da"
     },
     {
         "type": "file",
@@ -584,10 +598,24 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+        "sha512": "9f933ce797ca6f64ac7cc222145a15ac0047242f10b47c15c7e98758fdd0704a811d889e9e3e5d1d28236f1b42d161195d8b78c1c0faceb4049433e116e6607c",
+        "dest-filename": "3ce797ca6f64ac7cc222145a15ac0047242f10b47c15c7e98758fdd0704a811d889e9e3e5d1d28236f1b42d161195d8b78c1c0faceb4049433e116e6607c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/93"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
         "sha512": "cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
         "dest-filename": "7dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/b0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+        "sha512": "6cdefdf2015f417faf8b0dd1ef2ac6591aa7acdda84641245238e5e09367e04f06c716e3b46dc56eb108218de5f3f86bc14c0878266f8b842e3933f8304ad5ba",
+        "dest-filename": "fdf2015f417faf8b0dd1ef2ac6591aa7acdda84641245238e5e09367e04f06c716e3b46dc56eb108218de5f3f86bc14c0878266f8b842e3933f8304ad5ba",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/de"
     },
     {
         "type": "file",
@@ -612,10 +640,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.9.1.tgz",
-        "sha512": "4359d8c59722a38afe5bbd9c9c84556287c40328c1777986e3ba3ece6b3c1e50f9d735ad03f63125bd3525e8b917e8e45a181efcf4d02beba576c3e1e9dd3fe2",
-        "dest-filename": "d8c59722a38afe5bbd9c9c84556287c40328c1777986e3ba3ece6b3c1e50f9d735ad03f63125bd3525e8b917e8e45a181efcf4d02beba576c3e1e9dd3fe2",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/59"
+        "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.12.0.tgz",
+        "sha512": "b7fc629d5acc6ec121c258cb0e814eb469226656b163569c7996c71111804b4d849141c9a7d960b3ff8bf289172e56026834aa61d074e586fc0a8fa4aef82e5c",
+        "dest-filename": "629d5acc6ec121c258cb0e814eb469226656b163569c7996c71111804b4d849141c9a7d960b3ff8bf289172e56026834aa61d074e586fc0a8fa4aef82e5c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/fc"
     },
     {
         "type": "file",
@@ -686,6 +714,13 @@
         "sha512": "8c372d27f21541b6682729287876e15e93a5341a8635cc1724a268838d84e470cf53041349d8c21dd8a18e3d0396785e43b6e56d3e9d1ce69f340892f28a1028",
         "dest-filename": "2d27f21541b6682729287876e15e93a5341a8635cc1724a268838d84e470cf53041349d8c21dd8a18e3d0396785e43b6e56d3e9d1ce69f340892f28a1028",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8c/37"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+        "sha512": "a76abfb7f9a1bee3a3fd478b955eb9eba183fe0ba8c25af4847c42948d16f66ecc59890bd45d212e8fb401ec6cf4748f0ad4754974344c3dcc30aad765a8db89",
+        "dest-filename": "bfb7f9a1bee3a3fd478b955eb9eba183fe0ba8c25af4847c42948d16f66ecc59890bd45d212e8fb401ec6cf4748f0ad4754974344c3dcc30aad765a8db89",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a7/6a"
     },
     {
         "type": "file",
@@ -780,10 +815,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/builder-util/-/builder-util-24.8.1.tgz",
-        "sha512": "89b990e019e7a829c94cdadd99d3659e1178f247ea84dcd27aa14c5c72c897ea3dff2867e907ce695ae5a19f5852ede6d24deb7b1be54f9c1c922e8b5a98d367",
-        "dest-filename": "90e019e7a829c94cdadd99d3659e1178f247ea84dcd27aa14c5c72c897ea3dff2867e907ce695ae5a19f5852ede6d24deb7b1be54f9c1c922e8b5a98d367",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/b9"
+        "url": "https://registry.npmjs.org/builder-util/-/builder-util-24.9.4.tgz",
+        "sha512": "60da27deb6233d29b85c30e1a3dc03ea3abbbcb449654cbd151fb21599c7a16bef7550a765a90be0172d4e53c004fe3532f207e7293671367661f90e8468acb5",
+        "dest-filename": "27deb6233d29b85c30e1a3dc03ea3abbbcb449654cbd151fb21599c7a16bef7550a765a90be0172d4e53c004fe3532f207e7293671367661f90e8468acb5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/da"
     },
     {
         "type": "file",
@@ -801,10 +836,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-        "sha512": "0b79d0c5f159c45455a09a0628a23ccb730e128d76f4d43e160434f22c9ef8c938ccd65919d8dfb34e9b553afe0c14a503ae90d9511c3248bf71408fe127ab71",
-        "dest-filename": "d0c5f159c45455a09a0628a23ccb730e128d76f4d43e160434f22c9ef8c938ccd65919d8dfb34e9b553afe0c14a503ae90d9511c3248bf71408fe127ab71",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/79"
+        "url": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+        "sha512": "1874d2352608090eec707eec67e336ac5a294682e1f2dd9b2d25ba05b82bb4bb1a84e201e62c805497fd1a358addc6130da323e17741a4cd5c03aa484b42afdb",
+        "dest-filename": "d2352608090eec707eec67e336ac5a294682e1f2dd9b2d25ba05b82bb4bb1a84e201e62c805497fd1a358addc6130da323e17741a4cd5c03aa484b42afdb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/18/74"
     },
     {
         "type": "file",
@@ -822,10 +857,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-        "sha512": "0ebdec7ca44fea84dc8dfd8999498525f79532f5c175e83107489543979bd95d74b852540804bc381c9975503255bf315cdcf71a38d3823f642d6b194ea13a93",
-        "dest-filename": "ec7ca44fea84dc8dfd8999498525f79532f5c175e83107489543979bd95d74b852540804bc381c9975503255bf315cdcf71a38d3823f642d6b194ea13a93",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/bd"
+        "url": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+        "sha512": "ed54f5ddf9a3a2d2a91a2a425bd244400bac10f13e122f2797afe0e050409889b418e38b32e6bd3430e8fc35a9d190310abddc3eae59a41aa63c04200dd6b63f",
+        "dest-filename": "f5ddf9a3a2d2a91a2a425bd244400bac10f13e122f2797afe0e050409889b418e38b32e6bd3430e8fc35a9d190310abddc3eae59a41aa63c04200dd6b63f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/54"
     },
     {
         "type": "file",
@@ -913,10 +948,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.4.tgz",
-        "sha512": "70a496d017eb49a0149f1a60be95cf2da696fee9a0e1baa0e24dc63b526a9517e9c7e7795b41835f39c23245a8b4941e939326cf53095428509f3dc855a78c65",
-        "dest-filename": "96d017eb49a0149f1a60be95cf2da696fee9a0e1baa0e24dc63b526a9517e9c7e7795b41835f39c23245a8b4941e939326cf53095428509f3dc855a78c65",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/a4"
+        "url": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.6.tgz",
+        "sha512": "e9ba0655a825c1b941809a86cb19b8fb10a61067168275874961d8e6369de7c6b042107a81fb6ad06f076f3537f58a822181cc2c088bd728f0899dfa9bf08bf3",
+        "dest-filename": "0655a825c1b941809a86cb19b8fb10a61067168275874961d8e6369de7c6b042107a81fb6ad06f076f3537f58a822181cc2c088bd728f0899dfa9bf08bf3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/ba"
     },
     {
         "type": "file",
@@ -983,10 +1018,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-        "sha512": "13bb86913ce49357740722de49ce99b054bbf40c60fa6d4ffd5b2062cc47822b9cded1528fe323308c1ef74142e25380673341758ee490ed8fdb029db10d6f81",
-        "dest-filename": "86913ce49357740722de49ce99b054bbf40c60fa6d4ffd5b2062cc47822b9cded1528fe323308c1ef74142e25380673341758ee490ed8fdb029db10d6f81",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/bb"
+        "url": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+        "sha512": "ac132f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8",
+        "dest-filename": "2f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/13"
     },
     {
         "type": "file",
@@ -1018,10 +1053,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.9.1.tgz",
-        "sha512": "86e0be3ba86f1dddb851b8f7732d8632218b7b6c4614a377925a9530b01d71b07a49631dd723d2759bd5f16d4ed35202cc20919590c78afe15acd5209cf51f6d",
-        "dest-filename": "be3ba86f1dddb851b8f7732d8632218b7b6c4614a377925a9530b01d71b07a49631dd723d2759bd5f16d4ed35202cc20919590c78afe15acd5209cf51f6d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/e0"
+        "url": "https://registry.npmjs.org/discord-rpc/-/discord-rpc-4.0.1.tgz",
+        "sha512": "1cebc7a5bab9493459263408073c282a74348c7a656c45855a53c3c175ca9bf6c82e1e27ce3720ee636a965d1463b46c8c5a1a5c0edefe861bff896fa5d6b6cc",
+        "dest-filename": "c7a5bab9493459263408073c282a74348c7a656c45855a53c3c175ca9bf6c82e1e27ce3720ee636a965d1463b46c8c5a1a5c0edefe861bff896fa5d6b6cc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/eb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.12.0.tgz",
+        "sha512": "9d2db63b21d421870ae3452720b3ada82e507df77548dd4b8eacbfe9ef904761f5c0cde2341aca26811b0d17c499861a00b28d15190a3ea49b64a46c19405d3f",
+        "dest-filename": "b63b21d421870ae3452720b3ada82e507df77548dd4b8eacbfe9ef904761f5c0cde2341aca26811b0d17c499861a00b28d15190a3ea49b64a46c19405d3f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9d/2d"
     },
     {
         "type": "file",
@@ -1060,6 +1102,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+        "sha512": "23cf1361959cf578981d1438ff7739ae38df8248e12f25b696e18885e18445b350e8e63bc93c9b6a74a90d765af32ed550ff589837186be7b2ab871aee22ea58",
+        "dest-filename": "1361959cf578981d1438ff7739ae38df8248e12f25b696e18885e18445b350e8e63bc93c9b6a74a90d765af32ed550ff589837186be7b2ab871aee22ea58",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/cf"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
         "sha512": "ac2f9054d3095aff8cb4f824b74cbed2b54421d6edc550030295bd257ad4565cc77ad81cc9cccffc4ec3266589e1f242645d9c3dc064d256963bd647306dc399",
         "dest-filename": "9054d3095aff8cb4f824b74cbed2b54421d6edc550030295bd257ad4565cc77ad81cc9cccffc4ec3266589e1f242645d9c3dc064d256963bd647306dc399",
@@ -1067,24 +1116,24 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.9.1.tgz",
-        "sha512": "bfb06e6a40ee63ab0a31460cf267d01abc328c1a59fce6daaa77a75341fe8a010bd749dcea1b74e3daec0b0d87821441744c09c46201bb3b378db12135a3039a",
-        "dest-filename": "6e6a40ee63ab0a31460cf267d01abc328c1a59fce6daaa77a75341fe8a010bd749dcea1b74e3daec0b0d87821441744c09c46201bb3b378db12135a3039a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/b0"
+        "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.12.0.tgz",
+        "sha512": "747e0ef7393117115b0551686c8479140ef5c89d536520af8d9da6682b24a60ec25a3045f923514900138650f251f46e07e8c14ccc04333c00472c266a9d024b",
+        "dest-filename": "0ef7393117115b0551686c8479140ef5c89d536520af8d9da6682b24a60ec25a3045f923514900138650f251f46e07e8c14ccc04333c00472c266a9d024b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/7e"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-log/-/electron-log-5.0.1.tgz",
-        "sha512": "c78c27c07834d21fe89d64208e6bdc74b57b32b77d4d98f136cf0b997569aaf00d0dfe05b12b39c0b9733b29162dc685cd1dfee61755110f1cb66ad4c601e53c",
-        "dest-filename": "27c07834d21fe89d64208e6bdc74b57b32b77d4d98f136cf0b997569aaf00d0dfe05b12b39c0b9733b29162dc685cd1dfee61755110f1cb66ad4c601e53c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c7/8c"
+        "url": "https://registry.npmjs.org/electron-log/-/electron-log-5.1.1.tgz",
+        "sha512": "21fec75384a56e1db17e339738bc627e46e0bba1e6583349c973cb5be5cd4ce1cc7c52a2b20d2dac0dddffbb32caedb94be947a2c7ec77454c7c34a31a7d7e3f",
+        "dest-filename": "c75384a56e1db17e339738bc627e46e0bba1e6583349c973cb5be5cd4ce1cc7c52a2b20d2dac0dddffbb32caedb94be947a2c7ec77454c7c34a31a7d7e3f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/fe"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.8.1.tgz",
-        "sha512": "20535791dc4c57351dc1ea0b24d5d2ba95e4aa7be06eb9f7278be8827b8e634e8b692fe6d31bdf15821ffa8d4233c89fe83b96616a1014a3dc599b7f1548d93f",
-        "dest-filename": "5791dc4c57351dc1ea0b24d5d2ba95e4aa7be06eb9f7278be8827b8e634e8b692fe6d31bdf15821ffa8d4233c89fe83b96616a1014a3dc599b7f1548d93f",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/53"
+        "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.9.4.tgz",
+        "sha512": "16085b79531fc479de1e3b06db15120b434c65858e396841c5f64a3d36e26dc2740a33c7d0f87cc9be4250eeb69eacb05df039bb53adaba2bc78e74e8b1c6636",
+        "dest-filename": "5b79531fc479de1e3b06db15120b434c65858e396841c5f64a3d36e26dc2740a33c7d0f87cc9be4250eeb69eacb05df039bb53adaba2bc78e74e8b1c6636",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/08"
     },
     {
         "type": "file",
@@ -1095,17 +1144,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.1.7.tgz",
-        "sha512": "48d3a1622ce3926e044fe63c8a5272533715b05243b4837354dd53c879d978c89d6441b762805e6ccc9773f27a59289775468e8c2ee781e90deab369e9aadd1c",
-        "dest-filename": "a1622ce3926e044fe63c8a5272533715b05243b4837354dd53c879d978c89d6441b762805e6ccc9773f27a59289775468e8c2ee781e90deab369e9aadd1c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/48/d3"
+        "url": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.1.8.tgz",
+        "sha512": "8613937da14077ac111c07d468186700e61cfb29921825892ed164c38c49a8ebeda4798874d1e75c357d9b53070be03aab4f006f1e18920cb3fd1e4318a34031",
+        "dest-filename": "937da14077ac111c07d468186700e61cfb29921825892ed164c38c49a8ebeda4798874d1e75c357d9b53070be03aab4f006f1e18920cb3fd1e4318a34031",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/13"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron/-/electron-28.1.0.tgz",
-        "sha512": "f3663ba383d258f9f5a3f695c183ec826070e86c9fda5547a5a06edc47fc2eb2d65f1cad83b65166bfd1b43a8430ecd0a77fa672ecb786e1fce0cca37663f9d1",
-        "dest-filename": "3ba383d258f9f5a3f695c183ec826070e86c9fda5547a5a06edc47fc2eb2d65f1cad83b65166bfd1b43a8430ecd0a77fa672ecb786e1fce0cca37663f9d1",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/66"
+        "url": "https://registry.npmjs.org/electron/-/electron-29.1.0.tgz",
+        "sha512": "822255226d2c595a7ef15d465eb2aa2936fe87b9e8d0fde8a18a84777e000fdc0c2731a701e2febac8fe474d79e7fd2976fbcfd6683276703b95c68503633d97",
+        "dest-filename": "55226d2c595a7ef15d465eb2aa2936fe87b9e8d0fde8a18a84777e000fdc0c2731a701e2febac8fe474d79e7fd2976fbcfd6683276703b95c68503633d97",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/22"
     },
     {
         "type": "file",
@@ -1113,6 +1162,13 @@
         "sha512": "3128d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
         "dest-filename": "d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/28"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+        "sha512": "2f5f03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca",
+        "dest-filename": "03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/5f"
     },
     {
         "type": "file",
@@ -1137,6 +1193,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+        "sha512": "8f16b22ca4a1ac4aaacc9d1eba641b5614d840cdbb09f4f54f7e7e8028031682fcd892ec5ea4c9efacefe80d182ce8049cb50cbcbcec0ec188ae5f0d1694f681",
+        "dest-filename": "b22ca4a1ac4aaacc9d1eba641b5614d840cdbb09f4f54f7e7e8028031682fcd892ec5ea4c9efacefe80d182ce8049cb50cbcbcec0ec188ae5f0d1694f681",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/16"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+        "sha512": "65fe47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+        "dest-filename": "47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/fe"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
         "sha512": "526ffe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
         "dest-filename": "fe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
@@ -1144,10 +1214,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-        "sha512": "9347abda05242dff0ed332898808669139c9953bc8346bfbca00cd3db788b17fd3263189647ba1f41d94c5bb1a1249a5128f4c7e1ad2ce68489614652361979f",
-        "dest-filename": "abda05242dff0ed332898808669139c9953bc8346bfbca00cd3db788b17fd3263189647ba1f41d94c5bb1a1249a5128f4c7e1ad2ce68489614652361979f",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/47"
+        "url": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+        "sha512": "12b08730269ed7dbd1f2f4067b9d3122c5689b2d7dae0ea016edfeaf78e410ee3ab2e2cc58192cbd5ca81a0415fa339f97ce1948e4a59afe86c5af3d3e64c698",
+        "dest-filename": "8730269ed7dbd1f2f4067b9d3122c5689b2d7dae0ea016edfeaf78e410ee3ab2e2cc58192cbd5ca81a0415fa339f97ce1948e4a59afe86c5af3d3e64c698",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/b0"
     },
     {
         "type": "file",
@@ -1172,10 +1242,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-        "sha512": "1a8d7dc4ce93f69b823969ed89ed7f3fdf7b697c45b0e8b7ec9207456239d781dce999da1c6298f71161ad4eb9453e82701133668186d5ee8dabe0d3d3866d65",
-        "dest-filename": "7dc4ce93f69b823969ed89ed7f3fdf7b697c45b0e8b7ec9207456239d781dce999da1c6298f71161ad4eb9453e82701133668186d5ee8dabe0d3d3866d65",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1a/8d"
+        "url": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+        "sha512": "759ebe99ec6769321b481656828bb9d54e8e9b322160cd9570d76d893b48eea3cd666df9024a6bd1feafb70df0d4a9a7e4f628fad6557e1d775ab8694baa0ba9",
+        "dest-filename": "be99ec6769321b481656828bb9d54e8e9b322160cd9570d76d893b48eea3cd666df9024a6bd1feafb70df0d4a9a7e4f628fad6557e1d775ab8694baa0ba9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/9e"
     },
     {
         "type": "file",
@@ -1256,10 +1326,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-        "sha512": "c01ae8714d8b0975dafa5581b7c4682110fcf458bc39d0013836bf9049f27b28d2e5a64ee7f18dbc8e6c1083400ea3ff87c336f541d31d46f9dec52ee4886a77",
-        "dest-filename": "e8714d8b0975dafa5581b7c4682110fcf458bc39d0013836bf9049f27b28d2e5a64ee7f18dbc8e6c1083400ea3ff87c336f541d31d46f9dec52ee4886a77",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/1a"
+        "url": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+        "sha512": "b11543de55952175a0e81cbaf1937bbe1a3d6b5a5070dfd604568002c0c31739498efa06c743fccfb575b7bda0ac525f261bb760f641baedb97fb29ac368cdd7",
+        "dest-filename": "43de55952175a0e81cbaf1937bbe1a3d6b5a5070dfd604568002c0c31739498efa06c743fccfb575b7bda0ac525f261bb760f641baedb97fb29ac368cdd7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/15"
     },
     {
         "type": "file",
@@ -1281,6 +1351,13 @@
         "sha512": "ff21472b46868c51200c98c428fd29582a65b0f14f870c9fc1ebdffe957188dd2d984e0bf4b9b05b15ae91d2521dda02962e158102de86326dc10067aa6b0a73",
         "dest-filename": "472b46868c51200c98c428fd29582a65b0f14f870c9fc1ebdffe957188dd2d984e0bf4b9b05b15ae91d2521dda02962e158102de86326dc10067aa6b0a73",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/21"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+        "sha512": "d19b7eb372fb55fd5b8b0599dbd6804625582f1ee23069c4525f71df77db07f8f78d1f35bbf3b62dba8af819b508348d0ca56d27f623c18ed351de5291e2d02f",
+        "dest-filename": "7eb372fb55fd5b8b0599dbd6804625582f1ee23069c4525f71df77db07f8f78d1f35bbf3b62dba8af819b508348d0ca56d27f623c18ed351de5291e2d02f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d1/9b"
     },
     {
         "type": "file",
@@ -1312,10 +1389,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-        "sha512": "dfacb10e7e47ece1594256b4fe314999b20a4dd6404079e009e746c62326a4d7c464cd2c744793f967332d0ae32ba0fba366a2c8b6039e4c3447724ad10bf545",
-        "dest-filename": "b10e7e47ece1594256b4fe314999b20a4dd6404079e009e746c62326a4d7c464cd2c744793f967332d0ae32ba0fba366a2c8b6039e4c3447724ad10bf545",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/df/ac"
+        "url": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+        "sha512": "5fc72a30b2e27bb2ac3540d277378df0560af6b12de03b7aeceb06fc33469d84d20c11b8b850091419d47a257ecc2540bf0172e7a22333db07e758d568484dc7",
+        "dest-filename": "2a30b2e27bb2ac3540d277378df0560af6b12de03b7aeceb06fc33469d84d20c11b8b850091419d47a257ecc2540bf0172e7a22333db07e758d568484dc7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/c7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+        "sha512": "4cc28352722d7ba6df6f99d6bfb57f71a235ebd38782fc236fb5785a4794bdb410763af9ad62aa1c588a59bfdf70ec01f82cc14fea9b5a3be3f8357046c92922",
+        "dest-filename": "8352722d7ba6df6f99d6bfb57f71a235ebd38782fc236fb5785a4794bdb410763af9ad62aa1c588a59bfdf70ec01f82cc14fea9b5a3be3f8357046c92922",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4c/c2"
     },
     {
         "type": "file",
@@ -1382,10 +1466,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-        "sha512": "d204a8e2697fd23f7c637967824144a2dff386209e5ac6d822567eb993958332f22da530ef0c542fe9c24cfd1726f260d405ee949448dd4262f06b1b0eec5d18",
-        "dest-filename": "a8e2697fd23f7c637967824144a2dff386209e5ac6d822567eb993958332f22da530ef0c542fe9c24cfd1726f260d405ee949448dd4262f06b1b0eec5d18",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/04"
+        "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+        "sha512": "e6e621b091fc549053bfba2c960e01ce7258843a1123ac1a602c4c9827674eb702ac703f7c214aa13173d8928a1341dd0c5505effa10ba1cee99724aee968145",
+        "dest-filename": "21b091fc549053bfba2c960e01ce7258843a1123ac1a602c4c9827674eb702ac703f7c214aa13173d8928a1341dd0c5505effa10ba1cee99724aee968145",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/e6"
     },
     {
         "type": "file",
@@ -1417,6 +1501,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+        "sha512": "7dae3afadbf5024d143cad533b2fe966b2326cd36de070afed20f3c327e239992f64b11b8ec6642413ed0c756c8598db79c028006482db43232c31bfaabebbf6",
+        "dest-filename": "3afadbf5024d143cad533b2fe966b2326cd36de070afed20f3c327e239992f64b11b8ec6642413ed0c756c8598db79c028006482db43232c31bfaabebbf6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7d/ae"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
         "sha512": "9c5474ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5",
         "dest-filename": "74ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5",
@@ -1438,10 +1529,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-        "sha512": "5c0985d118e5ae3636dcc039d6adc796d7651b15295cfbe0d068a82a20fd5fa1c3dbc88c8e8d9d282f15ab09bb9677b818dafbf3e4474df96292d47a647d3dc0",
-        "dest-filename": "85d118e5ae3636dcc039d6adc796d7651b15295cfbe0d068a82a20fd5fa1c3dbc88c8e8d9d282f15ab09bb9677b818dafbf3e4474df96292d47a647d3dc0",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5c/09"
+        "url": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+        "sha512": "0213b9414723f2596b6c6d3d89684f536076d38275c673de2fc910995a2b4accbe4a38f5b24f2023287a714a1c1a61f82f452e840272fa124c440e26800e2615",
+        "dest-filename": "b9414723f2596b6c6d3d89684f536076d38275c673de2fc910995a2b4accbe4a38f5b24f2023287a714a1c1a61f82f452e840272fa124c440e26800e2615",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/13"
     },
     {
         "type": "file",
@@ -1487,17 +1578,17 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-        "sha512": "56c5fc79a21ec2f6acd319ef8a701ef5bc3859f21e383a466229225982c7f9d99ad09c3a28762a5a259f8509603952bc0fa3ef8ee6cae547383f488884870d56",
-        "dest-filename": "fc79a21ec2f6acd319ef8a701ef5bc3859f21e383a466229225982c7f9d99ad09c3a28762a5a259f8509603952bc0fa3ef8ee6cae547383f488884870d56",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/c5"
+        "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+        "sha512": "e7924d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae",
+        "dest-filename": "4d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/92"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-        "sha512": "eea13e88ff8ef9b805f5c944e7e528045cc4eb99a5062563ded282ae5350d0e8309b4063a53fe02b84a52d80ccc9b0e1e48dd30932a73cf6b4a0c1bb24362b86",
-        "dest-filename": "3e88ff8ef9b805f5c944e7e528045cc4eb99a5062563ded282ae5350d0e8309b4063a53fe02b84a52d80ccc9b0e1e48dd30932a73cf6b4a0c1bb24362b86",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/a1"
+        "url": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+        "sha512": "489d5a999009522652f8f86c54b7f9b46c9d95a541f04745a5a48ee209a250a50ec64f2ace7e40232e19789526876db39c8764fee300513da9977171cd5507f9",
+        "dest-filename": "5a999009522652f8f86c54b7f9b46c9d95a541f04745a5a48ee209a250a50ec64f2ace7e40232e19789526876db39c8764fee300513da9977171cd5507f9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/48/9d"
     },
     {
         "type": "file",
@@ -1508,10 +1599,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-        "sha512": "bd4a6d2954e920985c7332816e09d2f91b5cb98301f3ea0dccf2b6fc7a7785a9f3f099a90137669a02e049a69d5511240e6f9eda0887c18dd9464ca34880c314",
-        "dest-filename": "6d2954e920985c7332816e09d2f91b5cb98301f3ea0dccf2b6fc7a7785a9f3f099a90137669a02e049a69d5511240e6f9eda0887c18dd9464ca34880c314",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/4a"
+        "url": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+        "sha512": "d7fb61e0c1e39f09dcc17b085ba40cce5bd82fd906e5efc2a55bcb4597b85cf6bc4ce50d6c210baa6be10e69e436c023c1a1b8f88f202492f4241bd34cb3bda8",
+        "dest-filename": "61e0c1e39f09dcc17b085ba40cce5bd82fd906e5efc2a55bcb4597b85cf6bc4ce50d6c210baa6be10e69e436c023c1a1b8f88f202492f4241bd34cb3bda8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d7/fb"
     },
     {
         "type": "file",
@@ -1571,10 +1662,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-        "sha512": "83b766a6c872fa00fb9a1f3c382f4dc121932a87379322c0650454d66b79dc0c3fbe7bdf5e76c2f85ffb17b42861529b57e28dbc9c7cc00adec0acb5bd732d96",
-        "dest-filename": "66a6c872fa00fb9a1f3c382f4dc121932a87379322c0650454d66b79dc0c3fbe7bdf5e76c2f85ffb17b42861529b57e28dbc9c7cc00adec0acb5bd732d96",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/b7"
+        "url": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+        "sha512": "e45cadcff22b68c8eaa707dddf891edbc3d354c8d98c91b630f9f9b7b384e1e50250d7fc0406bb6f95944bdfd0bebea6c0e412ecc93abddb0c9e8e617be4fc5f",
+        "dest-filename": "adcff22b68c8eaa707dddf891edbc3d354c8d98c91b630f9f9b7b384e1e50250d7fc0406bb6f95944bdfd0bebea6c0e412ecc93abddb0c9e8e617be4fc5f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/5c"
     },
     {
         "type": "file",
@@ -1690,10 +1781,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.0.tgz",
-        "sha512": "503767c86bcc6a32545829226fb09e8bf76fc89aebbe8e0522bb2f48559d3e95d2528af35eb0c9d12f97e50e1995ab1f3e371ae32a8234db236c27a2cbc1457a",
-        "dest-filename": "67c86bcc6a32545829226fb09e8bf76fc89aebbe8e0522bb2f48559d3e95d2528af35eb0c9d12f97e50e1995ab1f3e371ae32a8234db236c27a2cbc1457a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/37"
+        "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.2.tgz",
+        "sha512": "1af723a23c289cc8d66d391f3299d51d5a975bfc0a3180df12963de3ff33cbc1c530ea9bfd52faa1e38dabdbfceeae2db5595a4cb9c65e7243e01e41d4e4c622",
+        "dest-filename": "23a23c289cc8d66d391f3299d51d5a975bfc0a3180df12963de3ff33cbc1c530ea9bfd52faa1e38dabdbfceeae2db5595a4cb9c65e7243e01e41d4e4c622",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1a/f7"
     },
     {
         "type": "file",
@@ -1711,6 +1802,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+        "sha512": "377c824bf35e82c381a2473c18074cf147267ec2a2492f1c8a985e0ff9e2bf3afbd341fe9ec30ec498d09efc0e711615b8591d1f4c0652f5b659b5c69ab6466d",
+        "dest-filename": "824bf35e82c381a2473c18074cf147267ec2a2492f1c8a985e0ff9e2bf3afbd341fe9ec30ec498d09efc0e711615b8591d1f4c0652f5b659b5c69ab6466d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/7c"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
         "sha512": "6438b768ff9f1bf2dc87207350cf34e158dd767c1f49fb1d798930b7c35c6ca46fa38ac592386ce39ea22c59f79366545af35ee22e3c5800836f36bc7e1ab6fb",
         "dest-filename": "b768ff9f1bf2dc87207350cf34e158dd767c1f49fb1d798930b7c35c6ca46fa38ac592386ce39ea22c59f79366545af35ee22e3c5800836f36bc7e1ab6fb",
@@ -1725,10 +1823,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/jimp/-/jimp-0.22.10.tgz",
-        "sha512": "9426872090204ceb299722730b5c3f95ac52c6b6d2b04070e1bc8ac1781474c9a1f9ac8fb2789d4db95e9d09be22f848b38e0672ebe56faa5dd8b434c1c29a2a",
-        "dest-filename": "872090204ceb299722730b5c3f95ac52c6b6d2b04070e1bc8ac1781474c9a1f9ac8fb2789d4db95e9d09be22f848b38e0672ebe56faa5dd8b434c1c29a2a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/26"
+        "url": "https://registry.npmjs.org/jimp/-/jimp-0.22.12.tgz",
+        "sha512": "4798d96980e77e4c4a272d5dc0ba63ffb72fca3c62725c54dc5e13ac8fc9e23dab4b49e2aba60350ca0f9f986cf060e93be3991a8ecacb4e7b091b567acca17e",
+        "dest-filename": "d96980e77e4c4a272d5dc0ba63ffb72fca3c62725c54dc5e13ac8fc9e23dab4b49e2aba60350ca0f9f986cf060e93be3991a8ecacb4e7b091b567acca17e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/98"
     },
     {
         "type": "file",
@@ -1767,10 +1865,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.0.tgz",
-        "sha512": "cdf03ee52bb060dd955aa375ff91d9683cd028b24768154c64820cfb0b988dda6d91a42cab30ddaa3a9ffa5659254b89ab569a9c7898f0b847f0b987faa05824",
-        "dest-filename": "3ee52bb060dd955aa375ff91d9683cd028b24768154c64820cfb0b988dda6d91a42cab30ddaa3a9ffa5659254b89ab569a9c7898f0b847f0b987faa05824",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/f0"
+        "url": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
+        "sha512": "494ffdef52ade6a5507c9a720ef795850fefc9afb986fae30a514e72bf1cd05ab968e0c98ccc2eb6b39f094f9e0a7543e60a71d50ddf12a932a26efbcc7d6222",
+        "dest-filename": "fdef52ade6a5507c9a720ef795850fefc9afb986fae30a514e72bf1cd05ab968e0c98ccc2eb6b39f094f9e0a7543e60a71d50ddf12a932a26efbcc7d6222",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/4f"
     },
     {
         "type": "file",
@@ -1949,6 +2047,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+        "sha512": "d9b20cf31f9501fe894f86ca0258d2d6a51680cb2a6513c6252e8549a84830f56f72d70d872569ec026eeeabb1396f63c24af205178a658e6d639258bf69ffed",
+        "dest-filename": "0cf31f9501fe894f86ca0258d2d6a51680cb2a6513c6252e8549a84830f56f72d70d872569ec026eeeabb1396f63c24af205178a658e6d639258bf69ffed",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d9/b2"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
         "sha512": "268e9d274e029928eece7c09492de951e5a677f1f47df4e59175e0c198be7aad540a6a90c0287e78bb183980b063df758b615a878875044302c78a938466ec88",
         "dest-filename": "9d274e029928eece7c09492de951e5a677f1f47df4e59175e0c198be7aad540a6a90c0287e78bb183980b063df758b615a878875044302c78a938466ec88",
@@ -2030,6 +2135,13 @@
         "sha512": "94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea",
         "dest-filename": "15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/ac"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+        "sha512": "44789a73d9af691c34c770184600c2d42c403fb1d370daeb102780f186097969e9a3ed90e427a0b598daa2d5935b10c6dd4786035728134e621f598f8d3ff69a",
+        "dest-filename": "9a73d9af691c34c770184600c2d42c403fb1d370daeb102780f186097969e9a3ed90e427a0b598daa2d5935b10c6dd4786035728134e621f598f8d3ff69a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/78"
     },
     {
         "type": "file",
@@ -2222,10 +2334,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
-        "sha512": "6e39e58843a61afdf2d5a3047d110c049f6d7cbdd64748b408a3e3eb50e748b6a8c564779cbaec42b11b08877ff2b178372445d1c0aa8ac4955f241858cfa609",
-        "dest-filename": "e58843a61afdf2d5a3047d110c049f6d7cbdd64748b408a3e3eb50e748b6a8c564779cbaec42b11b08877ff2b178372445d1c0aa8ac4955f241858cfa609",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/39"
+        "url": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+        "sha512": "d1c125895319121ac50f0321e12c48c95269a98a0e58327d3fcf79b45b92f97b8dcc8e54066064e54e4ee0ab897539d9a52048e0b140dbe66225a8b07d2c2530",
+        "dest-filename": "25895319121ac50f0321e12c48c95269a98a0e58327d3fcf79b45b92f97b8dcc8e54066064e54e4ee0ab897539d9a52048e0b140dbe66225a8b07d2c2530",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d1/c1"
     },
     {
         "type": "file",
@@ -2261,6 +2373,13 @@
         "sha512": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
         "dest-filename": "9e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/39"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+        "sha512": "324842ab3cc11293efc7143bd4c7746f52a4e755b4d65ad8be5333494688ccdb0e0dd77b9aa8628a649996bf957a0033e59e95cedf57836b6d13ffd70611f711",
+        "dest-filename": "42ab3cc11293efc7143bd4c7746f52a4e755b4d65ad8be5333494688ccdb0e0dd77b9aa8628a649996bf957a0033e59e95cedf57836b6d13ffd70611f711",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/48"
     },
     {
         "type": "file",
@@ -2509,10 +2628,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-5.10.0.tgz",
-        "sha512": "463db616541f73033a015a7ad56672dd1f0a9cb13a784195e9b27f376a821011c8449943352b2f7eb3f662215bb0ca64cb7300dead68e1244053c7d174f6a5a8",
-        "dest-filename": "b616541f73033a015a7ad56672dd1f0a9cb13a784195e9b27f376a821011c8449943352b2f7eb3f662215bb0ca64cb7300dead68e1244053c7d174f6a5a8",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/3d"
+        "url": "https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-5.11.0.tgz",
+        "sha512": "0109a3ac98369d1b2d9b6aed791e7b5ae4fe86aaff55d0b6a71ea35b074aa82b6ba0a5487d57e326e34dda1e29e91102cceda7b01b38f5397e300bb1894df5bb",
+        "dest-filename": "a3ac98369d1b2d9b6aed791e7b5ae4fe86aaff55d0b6a71ea35b074aa82b6ba0a5487d57e326e34dda1e29e91102cceda7b01b38f5397e300bb1894df5bb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/01/09"
     },
     {
         "type": "file",
@@ -2530,10 +2649,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-        "sha512": "d5b09211257a3effa2db51efa71a770f1fa9483f2520fb7cb958d1af1014b7f9dbb3061cfad2ba6366ed8942e3778f9f9ead793d7fa7a900c2ece7eded693070",
-        "dest-filename": "9211257a3effa2db51efa71a770f1fa9483f2520fb7cb958d1af1014b7f9dbb3061cfad2ba6366ed8942e3778f9f9ead793d7fa7a900c2ece7eded693070",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/b0"
+        "url": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+        "sha512": "127c1786b9705cc93d80abb9fdf971e6cbff6a7e7b024469946de14caebc5bb1510cdfa4f8e5818fae4cefbd7d3a403cd972c1c6b717d0a4878fe5f908e84e56",
+        "dest-filename": "1786b9705cc93d80abb9fdf971e6cbff6a7e7b024469946de14caebc5bb1510cdfa4f8e5818fae4cefbd7d3a403cd972c1c6b717d0a4878fe5f908e84e56",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/7c"
     },
     {
         "type": "file",
@@ -2544,10 +2663,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-        "sha512": "5686aa8db0492a25ad838c9170a050ee0ef09c69cb57733ca0bbd55b03a4d8f75863a3c415e811d6f7b35d1d2dc3a7d9185f5cb156a42118eb262cb6bde48115",
-        "dest-filename": "aa8db0492a25ad838c9170a050ee0ef09c69cb57733ca0bbd55b03a4d8f75863a3c415e811d6f7b35d1d2dc3a7d9185f5cb156a42118eb262cb6bde48115",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/86"
+        "url": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
+        "sha512": "8f8b7a71c73e56c2b0607b28fa41257399de6698edabd12744808566d5b206c2e88e199e17f64177f7a5aa6db658987f0738837bf48188e780b749b699f2c3d2",
+        "dest-filename": "7a71c73e56c2b0607b28fa41257399de6698edabd12744808566d5b206c2e88e199e17f64177f7a5aa6db658987f0738837bf48188e780b749b699f2c3d2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/8b"
     },
     {
         "type": "file",
@@ -2569,6 +2688,13 @@
         "sha512": "c270f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
         "dest-filename": "f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/70"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+        "sha512": "6f3c99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af",
+        "dest-filename": "99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/3c"
     },
     {
         "type": "file",
@@ -2635,6 +2761,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+        "sha512": "1e72ce091def8dc63c6dea0d2ed723679fe7c67d9a7e6304ea586b0eb79ba24a8c6a9f976de5bc9fd4d7a4f0cea9d18ae6a708de84f418a4d6eb00bb10c895a8",
+        "dest-filename": "ce091def8dc63c6dea0d2ed723679fe7c67d9a7e6304ea586b0eb79ba24a8c6a9f976de5bc9fd4d7a4f0cea9d18ae6a708de84f418a4d6eb00bb10c895a8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/72"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
         "sha512": "864457f14d568c915df0bb03276c90ff0596c5aa2912c0015355df90cf00fa3d3ef392401a9a6dd7a72bd56860e8a21b6f8a2453a32a97a04e8febaea7fc0a78",
         "dest-filename": "57f14d568c915df0bb03276c90ff0596c5aa2912c0015355df90cf00fa3d3ef392401a9a6dd7a72bd56860e8a21b6f8a2453a32a97a04e8febaea7fc0a78",
@@ -2646,6 +2779,13 @@
         "sha512": "637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
         "dest-filename": "153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/7f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+        "sha512": "8aae9e55523ae274104d162ad8ab44836776b94ecb125853270b07e18cc81d9b21c658199acff021ce15a03413946fc8bd522b04a1b4e82ad99e9d2abfb86471",
+        "dest-filename": "9e55523ae274104d162ad8ab44836776b94ecb125853270b07e18cc81d9b21c658199acff021ce15a03413946fc8bd522b04a1b4e82ad99e9d2abfb86471",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8a/ae"
     },
     {
         "type": "file",
@@ -2733,10 +2873,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-        "sha512": "efa49486d7ea4762239fec6595c2393f5a326a79c73470720fcd16d6ae38ee05379a9f46f4f4a919d5a68d43874433e21d869c224eba5bbb9b0d3b8f177044b5",
-        "dest-filename": "9486d7ea4762239fec6595c2393f5a326a79c73470720fcd16d6ae38ee05379a9f46f4f4a919d5a68d43874433e21d869c224eba5bbb9b0d3b8f177044b5",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/a4"
+        "url": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+        "sha512": "9d90fb9bd8823c2e60d2962671ac688182a08127cbb1dc65f287f743fa086ea0aa2cb20ef48005d065a35f5cfd3594473e25eff167b1e320c2699b20130d18f3",
+        "dest-filename": "fb9bd8823c2e60d2962671ac688182a08127cbb1dc65f287f743fa086ea0aa2cb20ef48005d065a35f5cfd3594473e25eff167b1e320c2699b20130d18f3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9d/90"
     },
     {
         "type": "file",
@@ -2796,10 +2936,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-        "sha512": "d455e4f44d879be433650ef3f8c7098872f8356d45d84cccbbd36af62df301a1aa89b69fa98c02554e96c9602ec90451cce971a2ef31652c972c437ca0a8f6e2",
-        "dest-filename": "e4f44d879be433650ef3f8c7098872f8356d45d84cccbbd36af62df301a1aa89b69fa98c02554e96c9602ec90451cce971a2ef31652c972c437ca0a8f6e2",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/55"
+        "url": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+        "sha512": "a5759cadac4cd2ec404beb4dd001bf045d93caa9873b4d78674ef452c27ea45bd8b914aaf0a1fc0e65a99db5ded2910f0c75d957715c01b2648a3279a0d1275b",
+        "dest-filename": "9cadac4cd2ec404beb4dd001bf045d93caa9873b4d78674ef452c27ea45bd8b914aaf0a1fc0e65a99db5ded2910f0c75d957715c01b2648a3279a0d1275b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a5/75"
     },
     {
         "type": "file",
@@ -2866,10 +3006,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz",
-        "sha512": "77aec93f874749b9b64eba458fc01b3bc0e72f52572f927dbb42aadb15ba7744c50db080dccba176df28ad70b6daeb65793563ecfaeab7cd9b68de9106f9c483",
-        "dest-filename": "c93f874749b9b64eba458fc01b3bc0e72f52572f927dbb42aadb15ba7744c50db080dccba176df28ad70b6daeb65793563ecfaeab7cd9b68de9106f9c483",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/77/ae"
+        "url": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+        "sha512": "12a862154e9d68e03c9298ce5932f4a25855385de2eceac5cd26221ac10c07c19c5d2f91af36ae004457eb9c4c78d595ab103a1d71f69baf59f4b68a29d8ac7e",
+        "dest-filename": "62154e9d68e03c9298ce5932f4a25855385de2eceac5cd26221ac10c07c19c5d2f91af36ae004457eb9c4c78d595ab103a1d71f69baf59f4b68a29d8ac7e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/a8"
     },
     {
         "type": "file",
@@ -2894,6 +3034,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+        "sha512": "b22ed0588eb350cab9e9b11216f6a0b66ccc7463ada317d1f927b3d753286df73bb66f9591472493d6d6d9479f7d319551b3a4b31992c34000da0b3c83bd4d09",
+        "dest-filename": "d0588eb350cab9e9b11216f6a0b66ccc7463ada317d1f927b3d753286df73bb66f9591472493d6d6d9479f7d319551b3a4b31992c34000da0b3c83bd4d09",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b2/2e"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
         "sha512": "9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
         "dest-filename": "a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
@@ -2905,6 +3052,13 @@
         "sha512": "02f1dcc99e499d27eade2a12ca3ac1907f725b89bb03293cffd332fc30fda2729ebbff787f0acca1c7a63b64002450259e70cdf990d2f998c0479b9ad7f3d5fd",
         "dest-filename": "dcc99e499d27eade2a12ca3ac1907f725b89bb03293cffd332fc30fda2729ebbff787f0acca1c7a63b64002450259e70cdf990d2f998c0479b9ad7f3d5fd",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/f1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+        "sha512": "17e3fd26297b52248a4a4a692220fde1d374ec0c2f162c6f2c88f53a0d5197d18632e362a499d5f49ce30fa5eeaa601e8acc06bd498d2e3af9705b97c0d4bbed",
+        "dest-filename": "fd26297b52248a4a4a692220fde1d374ec0c2f162c6f2c88f53a0d5197d18632e362a499d5f49ce30fa5eeaa601e8acc06bd498d2e3af9705b97c0d4bbed",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/e3"
     },
     {
         "type": "file",
@@ -2922,10 +3076,10 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-        "sha512": "c923e2323334fa92c37ed1e05d8e01cb4bacc08dd23ca2c3c3f8b75176e73bc33fa76f33a9ec425283e6405ad80feff5073846252b368b511158a240b622ebba",
-        "dest-filename": "e2323334fa92c37ed1e05d8e01cb4bacc08dd23ca2c3c3f8b75176e73bc33fa76f33a9ec425283e6405ad80feff5073846252b368b511158a240b622ebba",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/23"
+        "url": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+        "sha512": "76b3c59e44098a4fcefae3caa6a4a0af6da6a6e147a8a75b4bcdf988042b502ef72f61795a46e821177adda8bfd9883a2358f389f3c5287d8d4caf9c7e096420",
+        "dest-filename": "c59e44098a4fcefae3caa6a4a0af6da6a6e147a8a75b4bcdf988042b502ef72f61795a46e821177adda8bfd9883a2358f389f3c5287d8d4caf9c7e096420",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/b3"
     },
     {
         "type": "file",
@@ -2991,16 +3145,28 @@
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/59"
     },
     {
+        "type": "git",
+        "url": "https://git@github.com/devsnek/node-register-scheme.git",
+        "commit": "e7cc9a63a1f512565da44cb57316d9fb10750e17",
+        "dest": "flatpak-node/git-packages/register-scheme-e7cc9a63a1f512565da44cb57316d9fb10750e17"
+    },
+    {
         "type": "inline",
-        "contents": "002da450485a0e41c268f83ca9e1b6c0fa78de4a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz\", \"integrity\": \"sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==\", \"time\": 0, \"size\": 8435, \"metadata\": {\"url\": \"https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "bf722ce611a5fa7cc26c36c6deea02ff9f109d635b16b2db7338702e47c3",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/de"
+        "contents": "00681c0091c4a9242ff91c5cbf607470c181afaa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.22.12.tgz\", \"integrity\": \"sha512-sBfbzoOmJ6FczfG2PquiK84NtVGeScw97JsCC3rpQv1PHVWyW+uqWFF53+n3c8Y0P2HWlUjflEla2h/vWShvhg==\", \"time\": 0, \"size\": 5013, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "05da7ec30f0a35dd0331f03018d0d15161c2945331d12d98ee6178f551ec",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2d/ad"
     },
     {
         "type": "inline",
         "contents": "016523998c60ff736093dd7a0526402a673f73fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz\", \"integrity\": \"sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==\", \"time\": 0, \"size\": 11940, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "b5e9ca2e40744e7fa089861626d2a29c62363c01729964f4cf0c3e8ee632",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/2d/80"
+    },
+    {
+        "type": "inline",
+        "contents": "01ca38dda9a9a7e1a244b1507f6ca8efae142528\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/png/-/png-0.22.12.tgz\", \"integrity\": \"sha512-Mrp6dr3UTn+aLK8ty/dSKELz+Otdz1v4aAXzV5q53UDD2rbB5joKVJ/ChY310B+eRzNxIovbUF1KVrUsYdE8Hg==\", \"time\": 0, \"size\": 225206, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/png/-/png-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "19953d771f614c094efea0bd7151d96382f624e0a7e55556ad13da0bf9b3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f1/7a"
     },
     {
         "type": "inline",
@@ -3058,9 +3224,27 @@
     },
     {
         "type": "inline",
+        "contents": "066d687f244bbc3e90cacfdd8bc2730ca66f7111\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.22.12.tgz\", \"integrity\": \"sha512-c7TnhHlxm87DJeSnwr/XOLjJU/whoiKYY7r21SbuJ5nuH+7a78EW1teOaj5gEr2wYEd7QtkFqGlmyGXY/YclyQ==\", \"time\": 0, \"size\": 679219, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aad8bb3a3fbd9c8a30ec8135ea2cc8ad5fc799f2643a2f55384877d81775",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f5/eb"
+    },
+    {
+        "type": "inline",
         "contents": "0714a2a394f268aa28aece96be6799022392d402\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz\", \"integrity\": \"sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==\", \"time\": 0, \"size\": 4345, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "47e273da29b52c911f59eca44c62faa84be4bb59b1de259ba100ff968559",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/5a/8c"
+    },
+    {
+        "type": "inline",
+        "contents": "082538cd07ef3d87555b74d1f07ad283a93899de\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz\", \"integrity\": \"sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==\", \"time\": 0, \"size\": 2557, \"metadata\": {\"url\": \"https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0e997ee6a8d9d3e1fe2557e21886443526c541650898324cf96d122c87b6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/f0"
+    },
+    {
+        "type": "inline",
+        "contents": "085a04ebee03067286cbc18109064adbcd890f04\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz\", \"integrity\": \"sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==\", \"time\": 0, \"size\": 2765, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5f9e4f229cb04e29c07834547b435fad123e069f88d92499e29db0d9e35c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/72"
     },
     {
         "type": "inline",
@@ -3073,18 +3257,6 @@
         "contents": "0937e84e34e38f774cff2c326aa81211abcc6a51\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz\", \"integrity\": \"sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==\", \"time\": 0, \"size\": 8108, \"metadata\": {\"url\": \"https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "bd32d968042ac2f4a8c7bc2daf28d43817cf4673fd29911ea70dd4a68753",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/77"
-    },
-    {
-        "type": "inline",
-        "contents": "098ae5b3f85ee1019e9a925a04b69ad8441fe583\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-builder/-/electron-builder-24.9.1.tgz\", \"integrity\": \"sha512-v7BuakDuY6sKMUYM8mfQGrwyjBpZ/ObaqnenU0H+igEL10nc6ht049rsCw2HghRBdEwJxGIBuzs3jbEhNaMDmg==\", \"time\": 0, \"size\": 16818, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-builder/-/electron-builder-24.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "66e9845431ead6bcee0bc176def7d36d8542fdfc764a2fee7d4c523bb28a",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/24"
-    },
-    {
-        "type": "inline",
-        "contents": "09d84f126ba9624a8a27b8446e67498d569adf38\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.22.10.tgz\", \"integrity\": \"sha512-TN9xm6fI7XfxbMUQqFPZjv59Xdpf0tSiAQdINB4g6pJMWiVANR/74OtDONoy3KKpenu5Y38s+FkrtID/KcQAhw==\", \"time\": 0, \"size\": 5865, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a3f5a90f5624693194a7ebc4d807e237c55adf65cb4c2ce50b2dbb9e0979",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/e6"
     },
     {
         "type": "inline",
@@ -3154,9 +3326,21 @@
     },
     {
         "type": "inline",
+        "contents": "0ed776860877e6f75c18b21d3345700e380363e4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz\", \"integrity\": \"sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==\", \"time\": 0, \"size\": 7261, \"metadata\": {\"url\": \"https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ba07808feb3fc6e0e1444b1cadd78c71253f2e5c0fffa78f685d60e85d97",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/ac"
+    },
+    {
+        "type": "inline",
         "contents": "0fbc95ea5dea0d69d1f87ff0e1945487a26153d0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz\", \"integrity\": \"sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==\", \"time\": 0, \"size\": 15335, \"metadata\": {\"url\": \"https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3f6da259c54cf26b9cc43d7f33fb4b472cc1b9e9b0e5a0ae1463dfa3e2bd",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/70/11"
+    },
+    {
+        "type": "inline",
+        "contents": "112d21c540db1e5334054c93d5be97ddaca9952f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron/-/electron-29.1.0.tgz\", \"integrity\": \"sha512-giJVIm0sWVp+8V1GXrKqKTb+h7no0P3ooYqEd34AD9wMJzGnAeL+usj+R0155/0pdvvP1mgydnA7lcaFA2M9lw==\", \"time\": 0, \"size\": 152964, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron/-/electron-29.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d4b47bff53408e95c15402a05c33e34e598e8d3f1ed11bd576ee93fcf6e5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/74"
     },
     {
         "type": "inline",
@@ -3169,6 +3353,12 @@
         "contents": "13a4ebca831696b5a3cc9d8bbc89c5f2d9c31003\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz\", \"integrity\": \"sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==\", \"time\": 0, \"size\": 2030, \"metadata\": {\"url\": \"https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2937f0abc26f9973382cb3afa8b4b1d233a6a47ad4f3c5917ddb4997cddb",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/12"
+    },
+    {
+        "type": "inline",
+        "contents": "15bae2eed85db94b4f3672495b587b96f970475b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jimp/-/jimp-0.22.12.tgz\", \"integrity\": \"sha512-R5jZaYDnfkxKJy1dwLpj/7cvyjxiclxU3F4TrI/J4j2rS0niq6YDUMoPn5hs8GDpO+OZGo7Ky057CRtWesyhfg==\", \"time\": 0, \"size\": 2210503, \"metadata\": {\"url\": \"https://registry.npmjs.org/jimp/-/jimp-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "90ea451cce48a8d0160c1d9d015d4ff6e7f9ee9bf2002f8da4ba7685f5f0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/04"
     },
     {
         "type": "inline",
@@ -3208,6 +3398,12 @@
     },
     {
         "type": "inline",
+        "contents": "1aed941b4a2ef734df665575889d3a5c563a981f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.12.tgz\", \"integrity\": \"sha512-aeI64HD0npropd+AR76MCcvvRaa+Qck6loCOS03CkkxGHN5/r336qTM5HPUdHKMDOGzqknuVPA8+kK1t03z12g==\", \"time\": 0, \"size\": 145935, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "46f79f7886b539b51957889a6257a765028b80d172e6f074e75adb9a9607",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/46"
+    },
+    {
+        "type": "inline",
         "contents": "1b0c76fc9dbce4f0cbe5ba3a93221deca2dcf707\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz\", \"integrity\": \"sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==\", \"time\": 0, \"size\": 298937, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "38f3c3e795fbfc93216ea81b0cea3dcb25257bd1e4452dea6d855bcd3523",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/87"
@@ -3235,12 +3431,6 @@
         "contents": "1d7ea51940eb05c3e516bfa5c8ba4356485bdeef\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jake/-/jake-10.8.7.tgz\", \"integrity\": \"sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==\", \"time\": 0, \"size\": 40422, \"metadata\": {\"url\": \"https://registry.npmjs.org/jake/-/jake-10.8.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "dd6494bdda45c6c17d9ca8a5df902ac5fcf6d9eac12a1cb7fe2f0b9cbfc3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/bc/0a"
-    },
-    {
-        "type": "inline",
-        "contents": "1dd6d176e23b1d5c309256ccbee030e450f7c04b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-7.5.4.tgz\", \"integrity\": \"sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==\", \"time\": 0, \"size\": 26879, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-7.5.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "cd6df4c95195d9096bed558a3be3e1fa41277f7cc6d02b2d1f7c78cab3eb",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1f/b6"
     },
     {
         "type": "inline",
@@ -3280,9 +3470,21 @@
     },
     {
         "type": "inline",
-        "contents": "2135243ccc6f16706d039bc71def51fade1157ac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-log/-/electron-log-5.0.1.tgz\", \"integrity\": \"sha512-x4wnwHg00h/onWQgjmvcdLV7Mrd9TZjxNs8LmXVpqvANDf4FsSs5wLlzOykWLcaFzR3+5hdVEQ8ctmrUxgHlPA==\", \"time\": 0, \"size\": 31881, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-log/-/electron-log-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e646d7d704cec6497d5c51d2e19826bac7a5a4ad38274c456cfc1c50dff3",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/e2"
+        "contents": "2117904425543a010424b58f87c1c0368f7ba2a0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz\", \"integrity\": \"sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==\", \"time\": 0, \"size\": 5761919, \"metadata\": {\"url\": \"https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "59c34242f34eef8b551f2526cdf174963b467dcdfc8deab7b9dc9f12a97f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/57"
+    },
+    {
+        "type": "inline",
+        "contents": "227758491cee5f60d2a81c02f1822f18aa0f164c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz\", \"integrity\": \"sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==\", \"time\": 0, \"size\": 5090, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0c2e2758988030285c6764be745e00545556e0daf3581c4794d7b7644efd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/5a"
+    },
+    {
+        "type": "inline",
+        "contents": "2366403a88723f2ce6cf3108fce95195ce5887fb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz\", \"integrity\": \"sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==\", \"time\": 0, \"size\": 9591, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fb66a10fc76779f28a8a54174ad397ec7091711dfa34b744bc30ac0d7eff",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/ef"
     },
     {
         "type": "inline",
@@ -3310,9 +3512,21 @@
     },
     {
         "type": "inline",
+        "contents": "253148e7d8ad1532093939f63fffdce29ad9ecbd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.22.12.tgz\", \"integrity\": \"sha512-4AWZg+DomtpUA099jRV8IEZUfn1wLv6+nem4NRJC7L/82vxzLCgXKTxvNvBcNmJjT9yS1LAAmiJGdWKXG63/NA==\", \"time\": 0, \"size\": 5695, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "97a4e2312d9a28e5d41bdbd7539d7cff5937109c9718140fc8aa98a3b143",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/6c"
+    },
+    {
+        "type": "inline",
         "contents": "25685b71276e0bbf230b952f058dca235d321f38\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz\", \"integrity\": \"sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==\", \"time\": 0, \"size\": 32529, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "23d4e85b74dcb88b6bf1f7a3fba3c6b6a3c715191f86fb9e59d2bd61068d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/c6"
+    },
+    {
+        "type": "inline",
+        "contents": "261475c041d9ff2cb9c1ec3417a663652fd5bc1b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.6.tgz\", \"integrity\": \"sha512-6boGVaglwblBgJqGyxm4+xCmEGcWgnWHSWHY5jad58awQhB6gftq0G8HbzU39YqCIYHMLAiL1yjwiZ36m/CL8w==\", \"time\": 0, \"size\": 9875, \"metadata\": {\"url\": \"https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d6ee905640a1da347b5c56fa64134f0120d53bd0d3ae53b78c6f2014b422",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/cf"
     },
     {
         "type": "inline",
@@ -3322,9 +3536,9 @@
     },
     {
         "type": "inline",
-        "contents": "269990d4bc00f50f9494ace837cb624393a66b87\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz\", \"integrity\": \"sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==\", \"time\": 0, \"size\": 11620433, \"metadata\": {\"url\": \"https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "99c0f15d3708b1c4b1a54cb4e51f763e831c352bec16102c8eec9e326de3",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/30"
+        "contents": "2775a073d406be706b656a4aa1e9d0fb17505ee9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/core/-/core-0.22.12.tgz\", \"integrity\": \"sha512-l0RR0dOPyzMKfjUW1uebzueFEDtCOj9fN6pyTYWWOM/VS4BciXQ1VVrJs8pO3kycGYZxncRKhCoygbNr8eEZQA==\", \"time\": 0, \"size\": 77451, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/core/-/core-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aa8001bb5f520ee764095cf5f5fdf5f6e5b7c419e79cab3f6b7c55b62771",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/29"
     },
     {
         "type": "inline",
@@ -3364,6 +3578,18 @@
     },
     {
         "type": "inline",
+        "contents": "291755d36369fc4deb1d640bb3666628f03d9a30\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/types/-/types-0.22.12.tgz\", \"integrity\": \"sha512-wwKYzRdElE1MBXFREvCto5s699izFHNVvALUv79GXNbsOVqlwlOxlWJ8DuyOGIXoLP4JW/m30YyuTtfUJgMRMA==\", \"time\": 0, \"size\": 3408, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/types/-/types-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "306dd1277dd5c284ad04e668265be4e93e7fea316313ba1d0d7fb19ff798",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/44"
+    },
+    {
+        "type": "inline",
+        "contents": "29d802dfe9d659c9d7c24bf49d9821745df014a0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-5.11.0.tgz\", \"integrity\": \"sha512-AQmjrJg2nRstm2rteR57WuT+hqr/VdC2px6jWwdKqCtroKVIfVfjJuNN2h4p6RECzO2nsBs49Tl+MAuxiU31uw==\", \"time\": 0, \"size\": 30547, \"metadata\": {\"url\": \"https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-5.11.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d654e5c141f19775e9a88092c437e47a14359c339b7ef5a38dc531b83707",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/4e"
+    },
+    {
+        "type": "inline",
         "contents": "29f6f56d53a6cc5cf482ed443c60f2a900a0d93f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz\", \"integrity\": \"sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==\", \"time\": 0, \"size\": 2915, \"metadata\": {\"url\": \"https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "4d947695d5fef896bb84d57ecc3141429beb60968981dcdfd897299f74af",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/14"
@@ -3376,27 +3602,15 @@
     },
     {
         "type": "inline",
-        "contents": "2ae64388940ba033a7e68f6d6b5a53afb009c0e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz\", \"integrity\": \"sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==\", \"time\": 0, \"size\": 701993, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6163b31ffba4a6f6da52cfbc6de67c4b3e02e70b180673920f288dbaa453",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/bc"
-    },
-    {
-        "type": "inline",
-        "contents": "2ba8b94997c3d900c504928c6a855b08dbb8cedf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.22.10.tgz\", \"integrity\": \"sha512-d8j9BlUJYs/c994t4azUWSWmQq4LLPG4ecm8m6SSNqap+S/HlVQGqjYhJEBbY9EXkOTYB9vBL9bqwSM1Rr6paA==\", \"time\": 0, \"size\": 3498, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "805ff33b624cc08a440834738016ea2a17c2c8633df85ca7d1f6e4879435",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/4b"
+        "contents": "2acc3f04492ae79bae4ddbedaeb2bc243a5ea9ac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ws/-/ws-7.5.9.tgz\", \"integrity\": \"sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==\", \"time\": 0, \"size\": 29052, \"metadata\": {\"url\": \"https://registry.npmjs.org/ws/-/ws-7.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "83fe421e9d829df53a221dc110c81f86b73009f412b5542e474e6b5861e2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/8d"
     },
     {
         "type": "inline",
         "contents": "2bdf558ae872100445d39c9d6fac55b69312f3f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz\", \"integrity\": \"sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==\", \"time\": 0, \"size\": 5596, \"metadata\": {\"url\": \"https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c5ae5884dcf7678189db49acdbd1fee0fdb92a113a81dc0e2caf59f11279",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a2/b2"
-    },
-    {
-        "type": "inline",
-        "contents": "2cda40e729d6e3ff7772af489e8d33ef8d044a2f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.22.10.tgz\", \"integrity\": \"sha512-eP8KrzctuEoqibQAxi9WhbnoRosydhiwg+IYya3dKuKDBTrD9UHt+ERlPQ/lTNWHzV/l4S1ntV3r9s9saJgsXA==\", \"time\": 0, \"size\": 6424, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a751c19071f9fc8e06b3db36400a45d01b7f54b8066cae330fc23b4b6ecf",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/a1"
     },
     {
         "type": "inline",
@@ -3409,6 +3623,18 @@
         "contents": "2daf29a7da617d69581fa9220494f51c3215b0d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz\", \"integrity\": \"sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==\", \"time\": 0, \"size\": 18254, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "09dee9566ea463e6be194d0c3f2a44f3a08dc3e2dcf500fbe676e339e03b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/83"
+    },
+    {
+        "type": "inline",
+        "contents": "2deda18d3c4091999ab5d5f3c6aba2315de53721\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz\", \"integrity\": \"sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==\", \"time\": 0, \"size\": 100976, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7c8c151d9b4e4f128b24b563b8a46b5e186832c4b81c91e547b590c73c6b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/53"
+    },
+    {
+        "type": "inline",
+        "contents": "302b1eef253c29635ff9fe64a5a0210e9aff7b9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/discord-rpc/-/discord-rpc-4.0.1.tgz\", \"integrity\": \"sha512-HOvHpbq5STRZJjQIBzwoKnQ0jHplbEWFWlPDwXXKm/bILh4nzjcg7mNqll0UY7RsjFoaXA7e/oYb/4lvpda2zA==\", \"time\": 0, \"size\": 27918, \"metadata\": {\"url\": \"https://registry.npmjs.org/discord-rpc/-/discord-rpc-4.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fdd455047d2817df7fecf9a7c7431c73df74f11a32c8408dcf8da0a6002b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/c9"
     },
     {
         "type": "inline",
@@ -3430,15 +3656,15 @@
     },
     {
         "type": "inline",
-        "contents": "3395a2aa008c2dcb17f0fb8bb4748696420a1273\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz\", \"integrity\": \"sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==\", \"time\": 0, \"size\": 12011, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c70efbd08e87851b2c44507966444ab245afeaca3542be133a8611cb375b",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/27"
-    },
-    {
-        "type": "inline",
         "contents": "33d1cf24d9a5d9535b6ff1f64b0b5ac9caad0e41\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz\", \"integrity\": \"sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==\", \"time\": 0, \"size\": 3513, \"metadata\": {\"url\": \"https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "4ea6b895c004375f7977d61af095ceeb988964d34da00eb00e2b1cdaa8b6",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/8d"
+    },
+    {
+        "type": "inline",
+        "contents": "33ff39ef00c82c19dabf936f23e1f75479d98cc6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.22.12.tgz\", \"integrity\": \"sha512-z0w/1xH/v/knZkpTNx+E8a7fnasQ2wHG5ze6y5oL2dhH1UufNua8gLQXlv8/W56+4nJ1brhSd233HBJCo01BXA==\", \"time\": 0, \"size\": 6000, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b7d4eb89424ba070efff5fbd81c5506ba6df5ad34db39d5b331a0004729b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/ae"
     },
     {
         "type": "inline",
@@ -3448,9 +3674,27 @@
     },
     {
         "type": "inline",
+        "contents": "3668d6e45966c50d647f7784966538c35a88b84f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.12.0.tgz\", \"integrity\": \"sha512-nS22OyHUIYcK40UnILOtqC5Qffd1SN1Ljqy/6e+QR2H1wM3iNBrKJoEbDRfEmYYaALKNFRkKPqSbZKRsGUBdPw==\", \"time\": 0, \"size\": 87058, \"metadata\": {\"url\": \"https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.12.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ac268df0ba732166a839eab5ccba134b7466b21afb0e3fda77a7f406f228",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/80/61"
+    },
+    {
+        "type": "inline",
         "contents": "36bc2989f1f76c3abf36ec198411c5df8af97153\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tar/-/tar-6.2.0.tgz\", \"integrity\": \"sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==\", \"time\": 0, \"size\": 42424, \"metadata\": {\"url\": \"https://registry.npmjs.org/tar/-/tar-6.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "788b26af9f6857d94c4a66342b041d3631b0a8ae48e94c9f676334e026d3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/99"
+    },
+    {
+        "type": "inline",
+        "contents": "37d0378d79da196fd289aa048843fb73154121ef\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz\", \"integrity\": \"sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==\", \"time\": 0, \"size\": 2174, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0a148cc026eece20af4e33dcc9fba14e2964dfdb52be3a4ac291b0e7ba56",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/9d"
+    },
+    {
+        "type": "inline",
+        "contents": "37e8ea1dfe6767bcfa143576575e0330edab4587\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz\", \"integrity\": \"sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==\", \"time\": 0, \"size\": 7527, \"metadata\": {\"url\": \"https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "de0b42c2f82093bb385fb6e0de7c8edadd67ad116a2b4d0d89a5afded921",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/8b"
     },
     {
         "type": "inline",
@@ -3466,21 +3710,21 @@
     },
     {
         "type": "inline",
-        "contents": "391f84e20f8a8e934425497e3e772bb17b01226e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/core/-/core-0.22.10.tgz\", \"integrity\": \"sha512-ZKyrehVy6wu1PnBXIUpn/fXmyMRQiVSbvHDubgXz4bfTOao3GiOurKHjByutQIgozuAN6ZHWiSge1dKA+dex3w==\", \"time\": 0, \"size\": 80421, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/core/-/core-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3fdaa878188a4ea35987def8f82405a3c4a4cf6de0121618e4c5994fd8f7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3c/d7"
+        "contents": "39321f6916004e231b7257af53e5d8a0c6188908\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz\", \"integrity\": \"sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==\", \"time\": 0, \"size\": 99787, \"metadata\": {\"url\": \"https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5a67cb564ea18c341a7b8ed6e186b154cc1b7410968724da15d0148b66ba",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ac/56"
+    },
+    {
+        "type": "inline",
+        "contents": "39db6e99ed20c4b60d5d1484d850a917ed02674f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-builder/-/electron-builder-24.12.0.tgz\", \"integrity\": \"sha512-dH4O9zkxFxFbBVFobIR5FA71yJ1TZSCvjZ2maCskpg7CWjBF+SNRSQAThlDyUfRuB+jBTMwEMzwARywmap0CSw==\", \"time\": 0, \"size\": 16898, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-builder/-/electron-builder-24.12.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f31e22d3da0b5f904e9b95c74de8373c38195cf6d21f9210dc33ae6361bc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/75"
     },
     {
         "type": "inline",
         "contents": "3a335be62977bd5c9773c7e41da25d1a6a47cc3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz\", \"integrity\": \"sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==\", \"time\": 0, \"size\": 28613, \"metadata\": {\"url\": \"https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "b41f4759346e1d3b6651322d78c7983a4a546cdd6c18c3eb56c944571e4b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/aa"
-    },
-    {
-        "type": "inline",
-        "contents": "3a3df8b22e6e64a1c6560cde6459895980d1a06f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz\", \"integrity\": \"sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==\", \"time\": 0, \"size\": 4763, \"metadata\": {\"url\": \"https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "4805a9c08ab7bea9e9102c69f62073df7aef57dda1713bb521fb04a85c61",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/10/8e"
     },
     {
         "type": "inline",
@@ -3526,6 +3770,12 @@
     },
     {
         "type": "inline",
+        "contents": "3cd2fcdd8e3d37c3b7476cd33be3cf2ebdf92fcc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz\", \"integrity\": \"sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==\", \"time\": 0, \"size\": 4838, \"metadata\": {\"url\": \"https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e24e983a8272bd10e570d2ea410ed1ab143a2df36541c255e7f4181f8243",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/15/a2"
+    },
+    {
+        "type": "inline",
         "contents": "3cdbf69dadcb56348a8ff1c1cdcad493057103d0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz\", \"integrity\": \"sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==\", \"time\": 0, \"size\": 3387, \"metadata\": {\"url\": \"https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "67c972c58898526f6fcef84802f01306a300bc840e9107e05f7db9b1f12e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/c4"
@@ -3550,9 +3800,21 @@
     },
     {
         "type": "inline",
-        "contents": "3e873e9542497ee29be650d43b71fdd4e8b5932d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz\", \"integrity\": \"sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==\", \"time\": 0, \"size\": 3751, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f5b006175ccffb963838ff26f96ab47f4f221023ee835f8d63c40248ebbf",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/78/5e"
+        "contents": "3ea6b966ee10069b1961661a404afa063661ddee\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz\", \"integrity\": \"sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==\", \"time\": 0, \"size\": 14302, \"metadata\": {\"url\": \"https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d1c28b5fa917c3cfa94e3e87dab62fdc953e07fe93e0a3ecab080f58be93",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/43"
+    },
+    {
+        "type": "inline",
+        "contents": "3f5bb7ea9b419aeefa9668debcb0de6968a0eeb1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz\", \"integrity\": \"sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==\", \"time\": 0, \"size\": 26452, \"metadata\": {\"url\": \"https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "85e57baa9d925eb439766658c7cd72d41dfbdff23d9608399d25cb93b50e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/7a"
+    },
+    {
+        "type": "inline",
+        "contents": "3f89696a1c8af9e750cc9aba28c22d08371fbd9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz\", \"integrity\": \"sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==\", \"time\": 0, \"size\": 12880, \"metadata\": {\"url\": \"https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "236fddf087ef2b3d6bbe2692088cfc0a9e996ec49cda1ef9fc2855d2a564",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/97/e4"
     },
     {
         "type": "inline",
@@ -3598,12 +3860,6 @@
     },
     {
         "type": "inline",
-        "contents": "4384ab9ad35f008a58d1470f91338ef3e9388856\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-updater/-/electron-updater-6.1.7.tgz\", \"integrity\": \"sha512-SNOhYizjkm4ET+Y8ilJyUzcVsFJDtINzVN1TyHnZeMidZEG3YoBebMyXc/J6WSiXdUaOjC7ngekN6rNp6ardHA==\", \"time\": 0, \"size\": 110191, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-updater/-/electron-updater-6.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a5b0bc5799c84126eff3d0ae83a13560341138c436247c9af9d431690ba0",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/08/5a"
-    },
-    {
-        "type": "inline",
         "contents": "443377582687c1fe1f77f7b2103e349ed7be2fab\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz\", \"integrity\": \"sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==\", \"time\": 0, \"size\": 143727, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "40d05a0809760934aebff4c68bc3fd6fb716050dc3e9d5db8756b58a6015",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/b6"
@@ -3613,12 +3869,6 @@
         "contents": "448980b96c09ed65195efbf60c774b0f214f617b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz\", \"integrity\": \"sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==\", \"time\": 0, \"size\": 30541, \"metadata\": {\"url\": \"https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "708131fd7b70288ec630f44721ae379d4c8e2cf29afcca0017003c6c42d3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d2/bc"
-    },
-    {
-        "type": "inline",
-        "contents": "47156877dba632ce802261aad2e4d121f1e0c328\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.0.tgz\", \"integrity\": \"sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg==\", \"time\": 0, \"size\": 4388, \"metadata\": {\"url\": \"https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2db1d76737c9faba142c7c43e7da2487d371e989ae245ea7096012b9ac4d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/55"
     },
     {
         "type": "inline",
@@ -3634,6 +3884,12 @@
     },
     {
         "type": "inline",
+        "contents": "49f6252773a9073a49907947dcd1cc0984afac74\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.22.12.tgz\", \"integrity\": \"sha512-qpRM8JRicxfK6aPPqKZA6+GzBwUIitiHaZw0QrJ64Ygd3+AsTc7BXr+37k2x7QcyCvmKXY4haUrSIsBug4S3CA==\", \"time\": 0, \"size\": 4178, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c2a4b0d41cf69fa45366134e65b64b85475ce6734a16b34ce54686779279",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/24"
+    },
+    {
+        "type": "inline",
         "contents": "4a368b82a8b2774c922ad4245dec40662ab77040\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz\", \"integrity\": \"sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==\", \"time\": 0, \"size\": 10811, \"metadata\": {\"url\": \"https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "fd58b097f40ddba63bdd216a122c04f09909fdcc4f35711a3a1802a09fd3",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/4a"
@@ -3643,6 +3899,12 @@
         "contents": "4a4629ed63a491e0a4c167757207eb82c2c4df78\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-7z/-/node-7z-3.0.0.tgz\", \"integrity\": \"sha512-KIznWSxIkOYO/vOgKQfJEaXd7rgoFYKZbaurainCEdMhYc7V7mRHX+qdf2HgbpQFcdJL/Q6/XOPrDLoBeTfuZA==\", \"time\": 0, \"size\": 25949, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-7z/-/node-7z-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9301b05e136a9dec73940dce7e0f4f9853c9b26fe0249af59c796d38a0f0",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/97/41"
+    },
+    {
+        "type": "inline",
+        "contents": "4a4d7f159de3fba79a33f8c98147e4c623893b2f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/remote/-/remote-2.1.2.tgz\", \"integrity\": \"sha512-EPwNx+nhdrTBxyCqXt/pftoQg/ybtWDW3DUWHafejvnB1ZGGfMpv6e15D8KeempocjXe78T7WreyGGb3mlZxdA==\", \"time\": 0, \"size\": 18062, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/remote/-/remote-2.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "333355f49391e1e24fb7ffe5d990af80d306d5a15cdce2e8758847c893fc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/50"
     },
     {
         "type": "inline",
@@ -3670,12 +3932,6 @@
     },
     {
         "type": "inline",
-        "contents": "4b8fb4ff3606bbaa92c50c69f417612f110d8a37\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.10.tgz\", \"integrity\": \"sha512-TG/H0oUN69C9ArBCZg4PmuoixFVKIiru8282KzSB/Tp1I0xwX0XLTv3dJ5pobPlIgPcB+TmD4xAIdkCT4rtWxg==\", \"time\": 0, \"size\": 4350, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b7877fde20980947230e073c7a429458d26984c9579c99be809c516d11dc",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/e5"
-    },
-    {
-        "type": "inline",
         "contents": "4bf538be5b8b96a773e71d2194ade5220a8ff262\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/async/-/async-3.2.5.tgz\", \"integrity\": \"sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==\", \"time\": 0, \"size\": 149988, \"metadata\": {\"url\": \"https://registry.npmjs.org/async/-/async-3.2.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "89429d28fe1dc17867ebeca9e99423d5d3d7b23135dee56dd60bd6183294",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/8a"
@@ -3694,6 +3950,12 @@
     },
     {
         "type": "inline",
+        "contents": "4cffeac6ed901f903b58cab9fa8e597b8e6f9116\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.22.12.tgz\", \"integrity\": \"sha512-0So0rexQivnWgnhacX4cfkM2223YdExnJTTy6d06WbkfZk5alHUx8MM3yEzwoCN0ErO7oyqEWRnEkGC+As1FtA==\", \"time\": 0, \"size\": 5324, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dc281e2517f506fe25a71a7ecef2d66ec7a97c7aeef826447e9857f3aed2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/ab"
+    },
+    {
+        "type": "inline",
         "contents": "4d28bf1a2b925691ade5e3c9c2eca4e67150280e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz\", \"integrity\": \"sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==\", \"time\": 0, \"size\": 17325, \"metadata\": {\"url\": \"https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "976d338167b5c91b39d2951d214877b93a3f5205092b5c2e776de105830d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/45"
@@ -3709,12 +3971,6 @@
         "contents": "4ec271f4748298a1e0168ab97571a39915d336f7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz\", \"integrity\": \"sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==\", \"time\": 0, \"size\": 14004, \"metadata\": {\"url\": \"https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "b0ebc191e562e1a670020b47b4434cb6b65d1f7bbcaba33a89bded2616d1",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/91/7d"
-    },
-    {
-        "type": "inline",
-        "contents": "4f1bbf427f3523b3dd2c989df40dd3ecd59c331c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.10.tgz\", \"integrity\": \"sha512-6EI8Sl+mxYHEIy6Yteh6eknD+EZguKpNdr3sCKxNezmLR0+vK99vHcllo6uGSjXXiwtwS67Xqxn8SsoatL+UJQ==\", \"time\": 0, \"size\": 691897, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "86a4716c1944d689e943712981f91168cd324f14721a9f192dbf43886a2c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ac/fe"
     },
     {
         "type": "inline",
@@ -3769,12 +4025,6 @@
         "contents": "54692f9439030ea2c2c32aa9671f5c44dbace583\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz\", \"integrity\": \"sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==\", \"time\": 0, \"size\": 4927, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "62dbc9511af786c8c4a740679257471743aa49353a2dfec1eeb7a273aa66",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/2a"
-    },
-    {
-        "type": "inline",
-        "contents": "547144bb375a67bc062898eb618510e09b7c4ca4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/utils/-/utils-0.22.10.tgz\", \"integrity\": \"sha512-ztlOK9Mm2iLG2AMoabzM4i3WZ/FtshcgsJCbZCRUs/DKoeS2tySRJTnQZ1b7Roq0M4Ce+FUAxnCAcBV0q7PH9w==\", \"time\": 0, \"size\": 4172, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/utils/-/utils-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e95d52048644f67690e1a5d2e083c158e6d047d6244cb8ba1328d12fa620",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/d0"
     },
     {
         "type": "inline",
@@ -3838,21 +4088,15 @@
     },
     {
         "type": "inline",
-        "contents": "5c2515908676d6e7df4e3bc6ab137ef215535183\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.10.tgz\", \"integrity\": \"sha512-OaivlSYzpNTHyH/h7pEtl3A7F7TbsgytZs52GLX/xITW92ffgDgT6PkldIrMrET6ERh/hdijNQiew7IoEEr2og==\", \"time\": 0, \"size\": 1387842, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1272f8fe2ce84eb736650e29377eb6a9dad587b8fe4f8462dc6b141c7144",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/ed"
+        "contents": "5b53793a97c2e1337fe666c865281800701d4cb6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz\", \"integrity\": \"sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==\", \"time\": 0, \"size\": 4444, \"metadata\": {\"url\": \"https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7a69026a8e733ba3e0d403a8ab882ae7fabe57da458ba074db59260c20f1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/89"
     },
     {
         "type": "inline",
         "contents": "5c63a4fd69e2dfae0ff74c658006785d3bbf1e67\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz\", \"integrity\": \"sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==\", \"time\": 0, \"size\": 21539, \"metadata\": {\"url\": \"https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "ec19eb6f134ac8def05a2b0cb2dce598ac837ee5d56b3ff20d9a8844a39c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/18"
-    },
-    {
-        "type": "inline",
-        "contents": "5ce74faecf2cec649230bb62af91705451f7db5d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz\", \"integrity\": \"sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==\", \"time\": 0, \"size\": 4325, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "4b5ddfc904b8044d8a839f6862470e205c828f6b05a71ddaa6a918bc9ba5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fa/50"
     },
     {
         "type": "inline",
@@ -3883,12 +4127,6 @@
         "contents": "62473d3b358188b7659f2826b717a58cba78b1f6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz\", \"integrity\": \"sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==\", \"time\": 0, \"size\": 8042, \"metadata\": {\"url\": \"https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "117a77d49f173327aa6bce56a28f2e9428f69554be2276744c1afa38b2b1",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/19/c0"
-    },
-    {
-        "type": "inline",
-        "contents": "6281b5a5c3549110b717c486baeab0582b9a6990\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.10.tgz\", \"integrity\": \"sha512-e4t3L7Kedd96E0x1XjsTM6NcgulKUU66HdFTao7Tc9FYJRFSlttARZ/C6LEryGDm/i69R6bJEpo7BkNz0YL55Q==\", \"time\": 0, \"size\": 297809, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "33415f8ec148f8a08163e49e32eab119dfa68ca4563416e583817fd75d91",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/24"
     },
     {
         "type": "inline",
@@ -3928,6 +4166,12 @@
     },
     {
         "type": "inline",
+        "contents": "6744115e4c33a21dbf5cb1fd39593521f8d0ee25\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz\", \"integrity\": \"sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==\", \"time\": 0, \"size\": 9388, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "45de7955e517537b59ad7aaafb62a74ce6d4d627ae7ef04075b677009984",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/79"
+    },
+    {
+        "type": "inline",
         "contents": "6784529eed7dfe768a00bb8f26ac938d794f0dbe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz\", \"integrity\": \"sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==\", \"time\": 0, \"size\": 7231, \"metadata\": {\"url\": \"https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "24dfbb2c45c3b8a6e8d28b441cf345581a0030bd27ca640f5eb08a0236ec",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/72/82"
@@ -3952,9 +4196,15 @@
     },
     {
         "type": "inline",
-        "contents": "6bb09f37a18cd367595b2b7a5dfa171494f7f45a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugins/-/plugins-0.22.10.tgz\", \"integrity\": \"sha512-KDMZyM6pmvS8freB+UBLko1TO/k4D7URS/nphCozuH+P7i3UMe7NdckXKJ8u+WD6sqN0YFYvBehpkpnUiw/91w==\", \"time\": 0, \"size\": 5233, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugins/-/plugins-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ac8cb80f2a4e3a8188106c6cfbd1e2baccb3e98ff7c122628c2e68206e70",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/82"
+        "contents": "6b84b8f37c618e3624796e18c35d85e15b6f7d98\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz\", \"integrity\": \"sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==\", \"time\": 0, \"size\": 5338, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c2c4e4cf88f6f5a26a474eec1eb28a1a0c087f156fa82df974013a50081f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/65"
+    },
+    {
+        "type": "inline",
+        "contents": "6bf6483717055c693912a727d929932766db8113\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.12.tgz\", \"integrity\": \"sha512-E1LtMh4RyJsoCAfAkBRVSYyZDTtLq9p9LUiiYP0vPtXyxX4BiYBUYihTLSBlCQg5nF2e4OpQg7SPrLdJ66u7jg==\", \"time\": 0, \"size\": 1387843, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/tiff/-/tiff-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bf801d4537b63320f380002a9b4f1ba5e03b2e80024ca3ea02429f404752",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/7a"
     },
     {
         "type": "inline",
@@ -3967,6 +4217,12 @@
         "contents": "6e6cb181797b0667513cb0e46f631211fd3eb343\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz\", \"integrity\": \"sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==\", \"time\": 0, \"size\": 3411, \"metadata\": {\"url\": \"https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5e4a83442d291d5de897ec5988a37d07269e97c52ea66182b3be08b6b990",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/0f"
+    },
+    {
+        "type": "inline",
+        "contents": "6eb57b6bbec4a7ff7b0a4558288e31ef39cd1f54\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.2.tgz\", \"integrity\": \"sha512-GvcjojwonMjWbTkfMpnVHVqXW/wKMYDfEpY94/8zy8HFMOqb/VL6oeONq9v87q4ttVlaTLnGXnJD4B5B1OTGIg==\", \"time\": 0, \"size\": 4403, \"metadata\": {\"url\": \"https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2e4ef0eea9cecd696041daf9894648485834952c07bc5a873e6c28de97b4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/c8"
     },
     {
         "type": "inline",
@@ -3994,9 +4250,15 @@
     },
     {
         "type": "inline",
-        "contents": "718092134e764d837311486bbc0dc6e9fc9b31ed\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz\", \"integrity\": \"sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==\", \"time\": 0, \"size\": 564821, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f3a3b7af64bd6bb0f667be20f4b9cf25ab74d432ef8463e3b6b5be9df362",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/fe"
+        "contents": "70eb7855402a58b90fbae653bfc8ce83220e4cc5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugins/-/plugins-0.22.12.tgz\", \"integrity\": \"sha512-yBJ8vQrDkBbTgQZLty9k4+KtUQdRjsIDJSPjuI21YdVeqZxYywifHl4/XWILoTZsjTUASQcGoH0TuC0N7xm3ww==\", \"time\": 0, \"size\": 5232, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugins/-/plugins-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4146c3b5f850af7f9307256581827d2c22af64b7b7ad03e52d7c9a310760",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/91"
+    },
+    {
+        "type": "inline",
+        "contents": "7156d7167311866741c367cf47e105505478366b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.22.12.tgz\", \"integrity\": \"sha512-SWVXx1yiuj5jZtMijqUfvVOJBwOifFn0918ou4ftoHgegc5aHWW5dZbYPjvC9fLpvz7oSlptNl2Sxr1zwofjTg==\", \"time\": 0, \"size\": 5447, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "095a532ad5597a719c41d043dd7c689f77bba5a32c334a3876c32531407a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/eb"
     },
     {
         "type": "inline",
@@ -4006,9 +4268,9 @@
     },
     {
         "type": "inline",
-        "contents": "742c77698e3445b1920700d3ed38e2a6de517ac0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.10.tgz\", \"integrity\": \"sha512-1UXRl1Nw1KptZ1r0ANqtXOst9vGH51dq7keVKQzyyTO2lz4dOaezS9StuSTNh+RmiHg/SVPaFRpPfB0S/ln4Kg==\", \"time\": 0, \"size\": 145935, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/bmp/-/bmp-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "9ed9ceda318aea573ef899c7861682c940de1b49acad370389ce4fd55862",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/bc"
+        "contents": "746d1a2bd06b0ed8f8fc2d38416657f38fe8fbaf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builder-util/-/builder-util-24.9.4.tgz\", \"integrity\": \"sha512-YNon3rYjPSm4XDDho9wD6jq7vLRJZUy9FR+yFZnHoWvvdVCnZakL4BctTlPABP41MvIH5yk2cTZ2YfkOhGistQ==\", \"time\": 0, \"size\": 34058, \"metadata\": {\"url\": \"https://registry.npmjs.org/builder-util/-/builder-util-24.9.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b6ea507ca0d8d46af239ba5957484e6e8756ea4ea8951699555b2cd18cc0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/e4"
     },
     {
         "type": "inline",
@@ -4039,12 +4301,6 @@
         "contents": "7641368474869040e3961b45f849d8efca03e063\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz\", \"integrity\": \"sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==\", \"time\": 0, \"size\": 39740, \"metadata\": {\"url\": \"https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "339b9832e323abb280eb874ec64f59486423026430be7b1c2ec42ca7e1b7",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/6b"
-    },
-    {
-        "type": "inline",
-        "contents": "766c978715d5ae25a5655e02dd68850d83045a56\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.22.10.tgz\", \"integrity\": \"sha512-kJCwL5T1igfa0InCfkE7bBeqg26m46aoRt10ug+rvm11P6RrvRMGrgINFyIKB+mnB7CiyBN/MOula1CvLhSInQ==\", \"time\": 0, \"size\": 6003, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "53b98fcc5c0f6abf838e9eac03d89da189c8eeaa6126bb5f62e23798a351",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/41"
     },
     {
         "type": "inline",
@@ -4090,12 +4346,6 @@
     },
     {
         "type": "inline",
-        "contents": "7941e0045ee0246699251b3512847561dbd5e6d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz\", \"integrity\": \"sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==\", \"time\": 0, \"size\": 3383, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f40a5a56a747c294db5d4c1d2a6151bc75eb59695cb805c7025f8e5a4faf",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/d0"
-    },
-    {
-        "type": "inline",
         "contents": "7a9a77dba41e943a7bffb71813740b59450f1f6e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz\", \"integrity\": \"sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==\", \"time\": 0, \"size\": 10968, \"metadata\": {\"url\": \"https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6cbcccb53a97ca56a3f515079dad26301f0ca0937c940661aa824ba8282d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/0a"
@@ -4138,6 +4388,12 @@
     },
     {
         "type": "inline",
+        "contents": "7d880a538e4742f4963b3a13bc1d8a37a8bef13f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz\", \"integrity\": \"sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==\", \"time\": 0, \"size\": 297808, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "09dcb6f2e9d29b366cef41e3f950999c924c996eb69fd7fd92b6d8e6a43a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c2/53"
+    },
+    {
+        "type": "inline",
         "contents": "7ddafcb73a2e6f9bf126cdb16c87735c6e4dc015\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz\", \"integrity\": \"sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==\", \"time\": 0, \"size\": 4621, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f7c9e3404de9212aefe3706d0ad202a663b6af36dcd7532e19428d480a26",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/02"
@@ -4174,9 +4430,9 @@
     },
     {
         "type": "inline",
-        "contents": "7fd2fb93e7593d13af61d7513c90c333803a90b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz\", \"integrity\": \"sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==\", \"time\": 0, \"size\": 13993, \"metadata\": {\"url\": \"https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b1330001ff476d9c2acef532690571a3d5e5cd432f6a70845500116da794",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/d9"
+        "contents": "7fc1777cbef68b135fb5662b779b0ab60b9f4f65\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globals/-/globals-13.24.0.tgz\", \"integrity\": \"sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==\", \"time\": 0, \"size\": 9574, \"metadata\": {\"url\": \"https://registry.npmjs.org/globals/-/globals-13.24.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e17390a730569ab6dd04256333f695b69260fb845a72bf9ddd484b61861a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/41"
     },
     {
         "type": "inline",
@@ -4195,12 +4451,6 @@
         "contents": "8084d21181a492da6c12a3a6f9e3a0d167d55878\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/debug/-/debug-4.3.4.tgz\", \"integrity\": \"sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==\", \"time\": 0, \"size\": 13252, \"metadata\": {\"url\": \"https://registry.npmjs.org/debug/-/debug-4.3.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "656525756cff060f6b0afd0fdfb7c2c51fe35c1d0e4f66c6f6a09b475c55",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/de/3a"
-    },
-    {
-        "type": "inline",
-        "contents": "810e3753a492f70694b111393774671518ed94f8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz\", \"integrity\": \"sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==\", \"time\": 0, \"size\": 26290, \"metadata\": {\"url\": \"https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6d9a45104ef7b26c624c5766325e6017397a39448eb153b3d47e57e4fdb2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/f9"
     },
     {
         "type": "inline",
@@ -4228,12 +4478,6 @@
     },
     {
         "type": "inline",
-        "contents": "84010d39185b704d3cc8a7e56d35a5361115d1d8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.22.10.tgz\", \"integrity\": \"sha512-yRBs1230XZkz24uFTdTcSlZ0HXZpIWzM3iFQN56MzZ7USgdVZjPPDCQ8I9RpqfZ36nDflQkUO0wV7ucsi4ogow==\", \"time\": 0, \"size\": 5695, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "25777c0f8675d5cc06ca106a18a5b5a12ea4d0b9a9cb63fe8da5e19147c5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/53"
-    },
-    {
-        "type": "inline",
         "contents": "85795dea1ecf7c402ce8472ecdc63256cebb23d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz\", \"integrity\": \"sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==\", \"time\": 0, \"size\": 139293, \"metadata\": {\"url\": \"https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "0acdca37b8cc7145aae47941a4acde6fc2dd876377875417fbd0e59dba97",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/bf"
@@ -4243,6 +4487,18 @@
         "contents": "86109bffb8661f32d357b72ab5cde4a83492880d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz\", \"integrity\": \"sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==\", \"time\": 0, \"size\": 7556, \"metadata\": {\"url\": \"https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "b1ccc6576fd094e8ad4e6eef40ae1b375cc30655523ae64966330c83cfa7",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/ec"
+    },
+    {
+        "type": "inline",
+        "contents": "8625628573ad8e281f6921d99910409358bcafdd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz\", \"integrity\": \"sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==\", \"time\": 0, \"size\": 3549, \"metadata\": {\"url\": \"https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7c2f5d9c827fd3615923038cf2bfebd0771c0167efe046697fdad9393895",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/9a"
+    },
+    {
+        "type": "inline",
+        "contents": "8663e74bce71440ca491f4d4a0896dc63e6ca153\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz\", \"integrity\": \"sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==\", \"time\": 0, \"size\": 15194, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "48040636d38c63fc79e789dc1bdcc49ccbee888e4e43861bef1e105a656b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/0c"
     },
     {
         "type": "inline",
@@ -4300,15 +4556,9 @@
     },
     {
         "type": "inline",
-        "contents": "8cd034fb9b8408ddc0dcff1997afa989aa72470d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builder-util/-/builder-util-24.8.1.tgz\", \"integrity\": \"sha512-ibmQ4BnnqCnJTNrdmdNlnhF48kfqhNzSeqFMXHLIl+o9/yhn6QfOaVrloZ9YUu3m0k3rexvlT5wcki6LWpjTZw==\", \"time\": 0, \"size\": 33553, \"metadata\": {\"url\": \"https://registry.npmjs.org/builder-util/-/builder-util-24.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "114ce67450075c62e2ab166ba8439e74dd81d7c96007a6e31ae26f8c26c9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3c/91"
-    },
-    {
-        "type": "inline",
-        "contents": "8d6d014672aecc60ac43a3ebf0aa31020201fec2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.22.10.tgz\", \"integrity\": \"sha512-42GkGtTHWnhnwTMPVK/kXObZbkYIpQWfuIfy5EMEMk6zRj05zpv4vsjkKWfuemweZINwfvD7wDJF7FVFNNcZZg==\", \"time\": 0, \"size\": 5502, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3a675fb4a2f41bf8626619f319f880b21210d34a9f123253b921d7a17ca3",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d4/63"
+        "contents": "8c9b477af0084b3e4b0fdce366762ed11ab0e69e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz\", \"integrity\": \"sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==\", \"time\": 0, \"size\": 13369, \"metadata\": {\"url\": \"https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0380559f2aa3f48d6733aadf8843d8e3d9f1b92eaaa125de918fc91bbe9b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7c/e2"
     },
     {
         "type": "inline",
@@ -4324,21 +4574,15 @@
     },
     {
         "type": "inline",
-        "contents": "8e73dae4a85ea421df31516200ee643a1fb108b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.22.10.tgz\", \"integrity\": \"sha512-Wk9GX6eJMchX/ZAazVa70Fagu+OXMvHiPY+HrcEwcclL+p1wo8xAHEsf9iKno7Ja4EU9lLhbBRY5hYJyiKMEkg==\", \"time\": 0, \"size\": 5326, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c9307b1b2cbfe592eee2113c3b9182e25b801a0cafe13ad0d9495f03b683",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/3b"
-    },
-    {
-        "type": "inline",
-        "contents": "8eeaf3f7e36a8850805685846437dafa0e77e75e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.9.1.tgz\", \"integrity\": \"sha512-huC+O6hvHd24Ubj3cy2GMiGLe2xGFKN3klqVMLAdcbB6SWMd1yPSdZvV8W1O01ICzCCRlZDHiv4VrNUgnPUfbQ==\", \"time\": 0, \"size\": 86846, \"metadata\": {\"url\": \"https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "749731f807c0e1cb137cb782f3b99610495fd293857297291a25e2e3c438",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/41"
-    },
-    {
-        "type": "inline",
         "contents": "8f498db3c301f6f442fccce923dbf96a93ff776f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/plist/-/plist-3.1.0.tgz\", \"integrity\": \"sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==\", \"time\": 0, \"size\": 145420, \"metadata\": {\"url\": \"https://registry.npmjs.org/plist/-/plist-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2073ae784c88534a43261e1b45ea995702ed5b9c3b921f22c6957e6c9be9",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/1e"
+    },
+    {
+        "type": "inline",
+        "contents": "8ffe49a37573d2043bff7978b060be2b39fbd982\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz\", \"integrity\": \"sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==\", \"time\": 0, \"size\": 10706, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "837a5a5a38cb941877d2b7c866028f08f4f0b8b8f4b89c957a6c950b51d7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/a9"
     },
     {
         "type": "inline",
@@ -4384,15 +4628,33 @@
     },
     {
         "type": "inline",
+        "contents": "9385f8969684545c334eaaf0e84e4c6f1b6dd51e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz\", \"integrity\": \"sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==\", \"time\": 0, \"size\": 13141, \"metadata\": {\"url\": \"https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d10ebf5cbd78d0f49b94c1e06f9e67ae848f90c905a85b6e0b51d3666507",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/19"
+    },
+    {
+        "type": "inline",
         "contents": "938c1ed95c78e8b13c653b6ba8cf188de66980d8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/7zip-min/-/7zip-min-1.4.4.tgz\", \"integrity\": \"sha512-mYB1WW5tcXfZxUN4+2joKk4+6j8jp+mpO2YiMU5z1gNNFbACxI2ADasffsdNPovZSwn/E662ZIH5gRkFPMufmA==\", \"time\": 0, \"size\": 6077, \"metadata\": {\"url\": \"https://registry.npmjs.org/7zip-min/-/7zip-min-1.4.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c303f5354c45ae776e9a610a56ef8caf364b73380c066c4498d7ee712b23",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/87/54"
     },
     {
         "type": "inline",
+        "contents": "93a155478d5243faeda776a11ebc832145ffee14\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz\", \"integrity\": \"sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==\", \"time\": 0, \"size\": 4429, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ea55e4e584609a1f0ba14a730391c0b04141931864f08f4172886bec44f9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/7c"
+    },
+    {
+        "type": "inline",
         "contents": "94157a609fe722c2ce8e371484bd9efe98ff2efd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz\", \"integrity\": \"sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==\", \"time\": 0, \"size\": 9542, \"metadata\": {\"url\": \"https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "db09e99d2fc4b9d471366260d48b659687fefb56966562f29c82112f99a9",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/f9"
+    },
+    {
+        "type": "inline",
+        "contents": "94622c2e37810e8c4ad5fb8eacf51380cab6f808\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz\", \"integrity\": \"sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==\", \"time\": 0, \"size\": 4348, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b9a40b4b017323ef12ac8ae7fdba09d55be209d921676a681e9a35f44733",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/0c"
     },
     {
         "type": "inline",
@@ -4405,24 +4667,6 @@
         "contents": "94b8d6a4c5f1545ef6e579d9f7fde82cc95af232\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"integrity\": \"sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==\", \"time\": 0, \"size\": 3756, \"metadata\": {\"url\": \"https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f7afbc9eb60823c417e5dd1dd2f56b61e1b85cdd840120ff5644e6b03358",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/76"
-    },
-    {
-        "type": "inline",
-        "contents": "956e8de6a8562ae97419d49f60c98d8668370442\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.9.1.tgz\", \"integrity\": \"sha512-Q1nYxZcio4r+W72cnIRVYofEAyjBd3mG47o+zms8HlD51zWtA/YxJb01Jei5F+jkWhge/PTQK+uldsPh6d0/4g==\", \"time\": 0, \"size\": 917205, \"metadata\": {\"url\": \"https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "072ba5b487e9dfa6b08dca67f569cbc8b5ac6826928ab859bcd0fef80a35",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d3/33"
-    },
-    {
-        "type": "inline",
-        "contents": "95d2a484206ab1ecbf02eb969065b565d2598955\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz\", \"integrity\": \"sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==\", \"time\": 0, \"size\": 125366, \"metadata\": {\"url\": \"https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "45b1f97e2c7fba3ecdfbb7c5526b4b333acc0e2b58b54cc501a5ecbd30d2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/ff"
-    },
-    {
-        "type": "inline",
-        "contents": "966605ae63988fc7eade78a4504b1ee4ba0d3970\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz\", \"integrity\": \"sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==\", \"time\": 0, \"size\": 9503, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a90a08fbd83e369400051eca6b6737d7b65625d4883121e5b9e974fcc247",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/c3"
     },
     {
         "type": "inline",
@@ -4459,6 +4703,12 @@
         "contents": "9b081a9be63cf4abe9180e060516b93eb7a8d95e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz\", \"integrity\": \"sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==\", \"time\": 0, \"size\": 7907, \"metadata\": {\"url\": \"https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "7f36d855e73b72c900bef7ba44a2a553de3d77b218493b4ddb6ae6fce516",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/b7"
+    },
+    {
+        "type": "inline",
+        "contents": "9b4ded99b2ef2ddf8de9770c3214ea669753ef0f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz\", \"integrity\": \"sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==\", \"time\": 0, \"size\": 3762, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b947121c6635b25b64dd6a7aefecc356a8b85eb1bf4386079a9a2c4b2e6c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/2e"
     },
     {
         "type": "inline",
@@ -4513,12 +4763,6 @@
         "contents": "a0be89300eb8ed18b2befa067c479eba68163fb9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"integrity\": \"sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==\", \"time\": 0, \"size\": 2206, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f7d95a8e3571758f8b5d095a21909a8f6cdfe7fd2349f7f72b2801eef079",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/d5"
-    },
-    {
-        "type": "inline",
-        "contents": "a0cd195bf7bfd98dd71b886b98ff719da48ace41\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.4.tgz\", \"integrity\": \"sha512-cKSW0BfrSaAUnxpgvpXPLaaW/umg4bqg4k3GO1JqlRfpx+d5W0GDXznCMkWotJQek5Mmz1MJVChQnz3IVaeMZQ==\", \"time\": 0, \"size\": 9868, \"metadata\": {\"url\": \"https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "308e903c2cc1e2250353bb6aa1ac046475e4137e481fc9136a39d24286a5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/67"
     },
     {
         "type": "inline",
@@ -4582,21 +4826,33 @@
     },
     {
         "type": "inline",
-        "contents": "a7529f30883e05386823f2962a3974620bf0eb77\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz\", \"integrity\": \"sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==\", \"time\": 0, \"size\": 12939, \"metadata\": {\"url\": \"https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "39ebe5ac627328b6cae7766132db391cc58564a62300b023c375d1d1fd43",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/43"
+        "contents": "a6a11ed2167c1b104f7ad1e205563b12bd08fc2f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.22.12.tgz\", \"integrity\": \"sha512-Eo3DmfixJw3N79lWk8q/0SDYbqmKt1xSTJ69yy8XLYQj9svoBbyRpSnHR+n9hOw5pKXytHwUW6nU4u1wegHNoQ==\", \"time\": 0, \"size\": 6424, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "750167e77a252067a97d1961e89aaba9780041f1349d504c9fc0a4143de6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e5/25"
     },
     {
         "type": "inline",
-        "contents": "a758228941a0b7ecd43a4df48db83836b6304fa8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.22.10.tgz\", \"integrity\": \"sha512-InjiXvc7Gkzrx8VWtU97kDqV7ENnhHGPULymJWeZaF2aicud9Fpk4iCtd/DcZIrk7Cbe60A8RwNXN00HXIbSCg==\", \"time\": 0, \"size\": 5321, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c06fdea18ead5e30c54ab928f7a5bc3fd68bf8c894dc551079772120b1d8",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/26"
+        "contents": "a73a30fb7f21d32d20c0fef02abff48bcdbf2788\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-7.6.0.tgz\", \"integrity\": \"sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==\", \"time\": 0, \"size\": 27204, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-7.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1c7dd8a685585071b5021af13aa9d0083fbc0d3f4e04c7fbabc7fd7d6355",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/19/b5"
     },
     {
         "type": "inline",
-        "contents": "a8f4de0e64fea9104fd8f4b129d1c7ccf918071f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz\", \"integrity\": \"sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==\", \"time\": 0, \"size\": 8558, \"metadata\": {\"url\": \"https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0b17b890b1f50712bdb3f77cf6d3e6a01cdda9a3717abf817240808d8e65",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d4/40"
+        "contents": "a75e4d124ff1ae833155f8316d05ee459367cefb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.22.12.tgz\", \"integrity\": \"sha512-LGuUTsFg+fOp6KBKrmLkX4LfyCy8IIsROwoUvsUPKzutSqMJnsm3JGDW2eOmWIS/jJpPaeaishjlxvczjgII+Q==\", \"time\": 0, \"size\": 5320, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "278a5c5af25a53838f61abac529b6690fdf616ffcb370e7cebe87fcf0082",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/7c"
+    },
+    {
+        "type": "inline",
+        "contents": "a7ca01cbbd152acdb3dcc58956b260ff493558d6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.22.12.tgz\", \"integrity\": \"sha512-jYgGdSdSKl1UUEanX8A85v4+QUm+PE8vHFwlamaKk89s+PXQe7eVE3eNeSZX4inCq63EHL7cX580dMqkoC3ZLw==\", \"time\": 0, \"size\": 4031, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8cbdf0ff5f3a884501e99614648854d5e29012d61f3920a22dde8831ae9a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b1/b2"
+    },
+    {
+        "type": "inline",
+        "contents": "a87b848cafec0d656ba7ec2e260665a9e7ae8e33\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz\", \"integrity\": \"sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==\", \"time\": 0, \"size\": 740246, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c5b8fc4775a2f80790882a7bae9935fce19fe3765f54c17ae8583bfe6145",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/d9"
     },
     {
         "type": "inline",
@@ -4627,12 +4883,6 @@
         "contents": "acd5460562b8a43c4b1f61c31f5df33f060bbeb9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz\", \"integrity\": \"sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==\", \"time\": 0, \"size\": 3631, \"metadata\": {\"url\": \"https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "345b3ef650794d71afeb249f3d87e450bbca927038c157a46bbeec5afb50",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/8c/be"
-    },
-    {
-        "type": "inline",
-        "contents": "ad0f0d4d22e48fd302f9dffc25d644fae8361116\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz\", \"integrity\": \"sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==\", \"time\": 0, \"size\": 14373, \"metadata\": {\"url\": \"https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8e172e1fb6d5b2abd0b660d0807ba08f87ecac382fd62d3bf09dc03ecee4",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/20"
     },
     {
         "type": "inline",
@@ -4678,6 +4928,18 @@
     },
     {
         "type": "inline",
+        "contents": "b0cc1512e6403a785c9c924472b170a747c633dd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz\", \"integrity\": \"sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==\", \"time\": 0, \"size\": 11118, \"metadata\": {\"url\": \"https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "38185a6182b640b9b029914c320415cae3a1704ac6bf68cbfc1dcc56bb65",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/52"
+    },
+    {
+        "type": "inline",
+        "contents": "b15b0d470124114f29750c543fbbe305b2d9f661\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.22.12.tgz\", \"integrity\": \"sha512-m251Rop7GN8W0Yo/rF9LWk6kNclngyjIJs/VXHToGQ6EGveOSTSQaX2Isi9f9lCDLxt+inBIb7nlaLLxnvHX8Q==\", \"time\": 0, \"size\": 5501, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f545d91d343683b3e4a6d9481fa81c540e0b13b4b8091207a1ed5567a18e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/13/fa"
+    },
+    {
+        "type": "inline",
         "contents": "b172e2cd76fb97e0f9f5aa666ff6d4d80bfaa8b1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/levn/-/levn-0.4.1.tgz\", \"integrity\": \"sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==\", \"time\": 0, \"size\": 7465, \"metadata\": {\"url\": \"https://registry.npmjs.org/levn/-/levn-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "0bd207e4befdc1899d2abf0d3271f34fd6bd81eaaa9e7f4b005488802bb0",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/de"
@@ -4687,6 +4949,24 @@
         "contents": "b1a13b0d8e283e7955635c6a30416cb757b49e1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.9.tgz\", \"integrity\": \"sha512-FSvAol2Z8UP191sZtsUZwHIN0eGoGue3uEXGdWIH5228e9KH1YHXT7fN8Oa33UGf+FbqGTQg3sJfrRGzmVCaJA==\", \"time\": 0, \"size\": 13834, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "63b650acffacbc7b7edda15d170963d67773f4423c702b450a7d04481c37",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/ca"
+    },
+    {
+        "type": "inline",
+        "contents": "b22c6723d919c4b3afb1bd4964e0c16a1b35eda6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz\", \"integrity\": \"sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==\", \"time\": 0, \"size\": 5796, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "97e8d6081ac64bc68ba5fe52511d9f7d8928ad26edbf0f08ba3c733391a0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5b/93"
+    },
+    {
+        "type": "inline",
+        "contents": "b3425c5b0dcbc8e013abae044a4e99ffed20b26e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz\", \"integrity\": \"sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==\", \"time\": 0, \"size\": 21691, \"metadata\": {\"url\": \"https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9b4540d19340b48806945a1938a6ce3bd2c2088230b3ff60b97b6e964183",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/b6"
+    },
+    {
+        "type": "inline",
+        "contents": "b3acbc21bdeebd4f9ca35c7df6216d2c0a62cb98\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-log/-/electron-log-5.1.1.tgz\", \"integrity\": \"sha512-If7HU4Slbh2xfjOXOLxifkbgu6HmWDNJyXPLW+XNTOHMfFKisg0trA3d/7syyu25S+lHosfsd0VMfDSjGn1+Pw==\", \"time\": 0, \"size\": 33758, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-log/-/electron-log-5.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ccaad2d63c735f4143927653e17947427c6c883040a1529685a12807dcb1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/ee"
     },
     {
         "type": "inline",
@@ -4708,9 +4988,15 @@
     },
     {
         "type": "inline",
-        "contents": "b51b5a2370c3437f70276357ca52ea953ebf3cf8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.10.tgz\", \"integrity\": \"sha512-BOZ+YGaZlhU7c5ye65RxikicXH0Ki0It6/XHISvipR5WZrfjLjL2Ke20G+AGnwBQc76gKenVcMXVUCnEjtZV+Q==\", \"time\": 0, \"size\": 11146, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a605c1134a17405e694ae69d2bbab423abc9474fc8f9306aef462dbead9d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3c/31"
+        "contents": "b4a21926d8f4d41078dd48b4df26e945c7481c3c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-updater/-/electron-updater-6.1.8.tgz\", \"integrity\": \"sha512-hhOTfaFAd6wRHAfUaBhnAOYc+ymSGCWJLtFkw4xJqOvtpHmIdNHnXDV9m1MHC+A6q08Abx4Ykgyz/R5DGKNAMQ==\", \"time\": 0, \"size\": 110544, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-updater/-/electron-updater-6.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "03745b66ae3185ca2f9319533b88aef7ad98b2ede67929b5b0b1697a68e8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/15/4d"
+    },
+    {
+        "type": "inline",
+        "contents": "b4c8d7f52841d47a2c5c49e7e60705f2285f45d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz\", \"integrity\": \"sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==\", \"time\": 0, \"size\": 4991, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "619cb59d7aefbbd1a355d2bd395cc91907cc9583ff255d765fe300c759d8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/65"
     },
     {
         "type": "inline",
@@ -4744,9 +5030,9 @@
     },
     {
         "type": "inline",
-        "contents": "b82c9781e3ced48e8c16765eb1a9fad49e78304c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.22.10.tgz\", \"integrity\": \"sha512-1U3VloIR+beE1kWPdGEJMiE2h1Do29iv3w8sBbvPyRP4qXxRFcDpmCGtctsrKmb1krlBFlj8ubyAY90xL+5n9w==\", \"time\": 0, \"size\": 677360, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c2ae0f8f5a532728c88a9ee4600cd6f0b9299a761e2b5d48a2532012cd9d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/15/5b"
+        "contents": "b817f1d5c53c105fcd3cf7263ffc383a06807dcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz\", \"integrity\": \"sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==\", \"time\": 0, \"size\": 565453, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d1e43dfa48a6bcd7f0bd12d6b269abfe418eaab2f6b473a43e42e149c988",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/62/44"
     },
     {
         "type": "inline",
@@ -4756,9 +5042,9 @@
     },
     {
         "type": "inline",
-        "contents": "b8636c3e266dcbcb04f2a6b273a5ad708911a743\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/remote/-/remote-2.0.10.tgz\", \"integrity\": \"sha512-3SFKKaQXcyWgwmibud+UqJl/XlHOgLcI3fwtB9pNelPSJAcTxocOJrF6FaxBIQaj1+R05Di6xuAswZpXAW7xhA==\", \"time\": 0, \"size\": 17879, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/remote/-/remote-2.0.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b720076dea445f3ff96d998cd6e5fc1c73e398e3888f2e766eaa4bd50326",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f9/0f"
+        "contents": "b843225eae99d5d4ef715cb35d7d71eb78dbf9d5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz\", \"integrity\": \"sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==\", \"time\": 0, \"size\": 125841, \"metadata\": {\"url\": \"https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "82fdd5a4a3564a4f73933dd5231ba0e49694b2215efd2ed439502668ab12",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/47"
     },
     {
         "type": "inline",
@@ -4768,15 +5054,33 @@
     },
     {
         "type": "inline",
+        "contents": "b9d627f605e58e502ceec3836d3d7a3a4b9bcbeb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz\", \"integrity\": \"sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==\", \"time\": 0, \"size\": 31523, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4070281d8c2d7c965486ebb68b01ec17ecf3414998638ba7465647c29678",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a6/44"
+    },
+    {
+        "type": "inline",
         "contents": "ba0eea9539e729805459d53e59bdc46ed7f4fb8a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz\", \"integrity\": \"sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==\", \"time\": 0, \"size\": 2351, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "697b69adbf3b0aa858654f58ee05d7db3e2cef5a91cf89d1157d2807aaec",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/c6/7e"
     },
     {
         "type": "inline",
+        "contents": "ba4e6f3f67ef0026e03f1ef61df9604c7bf6ebd3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz\", \"integrity\": \"sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==\", \"time\": 0, \"size\": 14437, \"metadata\": {\"url\": \"https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b89d90429dcb62429a49903ea9faf632e34417bae7292f6ab4406d769066",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dc/51"
+    },
+    {
+        "type": "inline",
         "contents": "ba9eb5b7f80a3dc684a8ee1dc0f8cf5a2930d53c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz\", \"integrity\": \"sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==\", \"time\": 0, \"size\": 13345, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "9ac1f50c0206eb56636af733d6f102ce6fa02fc16334322dc6d3a6c0c3d7",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/78/1b"
+    },
+    {
+        "type": "inline",
+        "contents": "bb15f04bbf49dba533a1ee433714cae4221c2a5f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.12.tgz\", \"integrity\": \"sha512-Rq26XC/uQWaQKyb/5lksCTCxXhtY01NJeBN+dQv5yNYedN0i7iYu+fXEoRsfaJ8xZzjoANH8sns7rVP4GE7d/Q==\", \"time\": 0, \"size\": 152218, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c5e048de205083766ef1392c6c9d69d161c79622f8d6531f2e882c6234e8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8e/05"
     },
     {
         "type": "inline",
@@ -4798,15 +5102,15 @@
     },
     {
         "type": "inline",
-        "contents": "bc9bbd4bb6e3c8711a7ba19b4becb4680b807287\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-publish/-/electron-publish-24.8.1.tgz\", \"integrity\": \"sha512-IFNXkdxMVzUdweoLJNXSupXkqnvgbrn3J4vognuOY06LaS/m0xvfFYIf+o1CM8if6DuWYWoQFKPcWZt/FUjZPw==\", \"time\": 0, \"size\": 19955, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-publish/-/electron-publish-24.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "bb85dd3929bfb5a480f9dbae2eae44b9eab952a52c112da9e9d6573e60a9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/0c"
-    },
-    {
-        "type": "inline",
         "contents": "bcc94283cb3f1228bea4770aa0688dcd1791a3d8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz\", \"integrity\": \"sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==\", \"time\": 0, \"size\": 1609, \"metadata\": {\"url\": \"https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c06d275269c6d6b921feebc2470f62b1c8f36f3a86affdc737fe608cc3fa",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/8d"
+    },
+    {
+        "type": "inline",
+        "contents": "bce181973f43910a35d1c476b0dad330df08105e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz\", \"integrity\": \"sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==\", \"time\": 0, \"size\": 4347, \"metadata\": {\"url\": \"https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "017b6ce66c47c8dccb26773b58e94337c766153ff0b2fa9b1004a21bf6c2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/33"
     },
     {
         "type": "inline",
@@ -4834,21 +5138,21 @@
     },
     {
         "type": "inline",
-        "contents": "bdeacc7a9e62ae831eca7f6dfca7d01b098ef35a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-5.10.0.tgz\", \"integrity\": \"sha512-Rj22FlQfcwM6AVp61WZy3R8KnLE6eEGV6bJ/N2qCEBHIRJlDNSsvfrP2YiFbsMpky3MA3q1o4SRAU8fRdPalqA==\", \"time\": 0, \"size\": 30487, \"metadata\": {\"url\": \"https://registry.npmjs.org/sdfz-demo-parser/-/sdfz-demo-parser-5.10.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0c9668cbc7c30f69817b29fbf83d625652a4f979f23be887070401b992b0",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e5/e1"
-    },
-    {
-        "type": "inline",
         "contents": "bdf94d948b168388e33bd2e1d571bad282a23440\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz\", \"integrity\": \"sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==\", \"time\": 0, \"size\": 9408, \"metadata\": {\"url\": \"https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "cc8592ab15d662d89edc5604d9f6347e26fbca3465f5f245b65eefb11d93",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/2e/c8"
     },
     {
         "type": "inline",
-        "contents": "be6acb3dce1eec6dccb08212f8a92fbc1cd1359a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/png/-/png-0.22.10.tgz\", \"integrity\": \"sha512-RYinU7tZToeeR2g2qAMn42AU+8OUHjXPKZZ9RkmoL4bguA1xyZWaSdr22/FBkmnHhOERRlr02KPDN1OTOYHLDQ==\", \"time\": 0, \"size\": 225207, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/png/-/png-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "7a57aacb3aee3fea3e37bad737e4796e7057abaca5677b582877dcefdce7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/89"
+        "contents": "be3bbebce727d73195c8ca0c08c08f57e411f969\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.12.0.tgz\", \"integrity\": \"sha512-t/xinVrMbsEhwljLDoFOtGkiZlaxY1aceZbHERGAS02EkUHJp9lgs/+L8okXLlYCaDSqYdB05Yb8Co+krvguXA==\", \"time\": 0, \"size\": 925243, \"metadata\": {\"url\": \"https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.12.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "89408bd485839ef48d671e3ae44d7a35fe506afd5f23340cf2493969061d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ea/eb"
+    },
+    {
+        "type": "inline",
+        "contents": "bfc89c2918f00635a94c461ae0194940059e8e88\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/gif/-/gif-0.22.12.tgz\", \"integrity\": \"sha512-y6BFTJgch9mbor2H234VSjd9iwAhaNf/t3US5qpYIs0TSbAvM02Fbc28IaDETj9+4YB4676sz4RcN/zwhfu1pg==\", \"time\": 0, \"size\": 140559, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/gif/-/gif-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4a2d3d8342ad259dd87b37dfee9de214b1f05c6740cc0d66c8e5453f89c5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/c2"
     },
     {
         "type": "inline",
@@ -4861,6 +5165,12 @@
         "contents": "c0f57ec5579380abe0aea95565833a529a477bb8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz\", \"integrity\": \"sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==\", \"time\": 0, \"size\": 87152, \"metadata\": {\"url\": \"https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "303d809759cacfacc465b075f4cc6a5d71e47fd1187d9de4719edd376736",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/e2/08"
+    },
+    {
+        "type": "inline",
+        "contents": "c1b8664f6fda8e8be3cf960168eb7c0e5353f811\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/utils/-/utils-0.22.12.tgz\", \"integrity\": \"sha512-yJ5cWUknGnilBq97ZXOyOS0HhsHOyAyjHwYfHxGbSyMTohgQI6sVyE8KPgDwH8HHW/nMKXk8TrSwAE71zt716Q==\", \"time\": 0, \"size\": 4170, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/utils/-/utils-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "68891b8720147da369271ee5d9fe690098c14e63ae3eca56c6b8bc3a0907",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/03"
     },
     {
         "type": "inline",
@@ -4888,15 +5198,15 @@
     },
     {
         "type": "inline",
-        "contents": "c4e00a51266aa629ca1a5fa8fbc4897a187bce5d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.22.10.tgz\", \"integrity\": \"sha512-DA2lSnU0TgIRbAgmXaxroYw3Ad6J2DOFEoJp0NleSm2h3GWbZEE5yW9U2B6hD3iqn4AenG4E2b2WzHXZyzSutw==\", \"time\": 0, \"size\": 577074, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "faf11cded86df5a1b8c3c29bfbcd7eabb9f96115f1013115b5e073caf78c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/4e"
-    },
-    {
-        "type": "inline",
         "contents": "c51a09cf7648f6023683c181b1ee51995dd0bfcd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse-dds/-/parse-dds-1.2.1.tgz\", \"integrity\": \"sha512-oE88N8mzUi9d26tAaKVc0clxi6AjeTSWpLwgtcEVjXTYY1MW58w8FctmM9gGgvFd6YGu1/eFFYVeDVnlMsKBtA==\", \"time\": 0, \"size\": 3928, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse-dds/-/parse-dds-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d506b33c4fc5dc976b430eecc60d678144cc6aa309aaf46592803eafe8b7",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/4f"
+    },
+    {
+        "type": "inline",
+        "contents": "c69a3c7bc66edccdea159dbd5f463f7423ff88e8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz\", \"integrity\": \"sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==\", \"time\": 0, \"size\": 3778, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4d18a20523c8a47e4d0e7eda449a36b43f55f82fff6fde9b656ca5a02e35",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/7e"
     },
     {
         "type": "inline",
@@ -4915,6 +5225,12 @@
         "contents": "c8a5706006c7272b34109041e53fbf4865386e30\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"integrity\": \"sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==\", \"time\": 0, \"size\": 11577, \"metadata\": {\"url\": \"https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "375aec77f76404d91225e72006a0105b2a6ec04bb02cfa365ebcd4a0232b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/7c"
+    },
+    {
+        "type": "inline",
+        "contents": "c8cc4c9c46143e6c020608cf70fe93a1d88cec30\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz\", \"integrity\": \"sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==\", \"time\": 0, \"size\": 13466, \"metadata\": {\"url\": \"https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3d9bb9c6590c443d48fbe343cb1244fa7cb9c69d44f46e5f61c7a192b674",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/a8"
     },
     {
         "type": "inline",
@@ -4960,12 +5276,6 @@
     },
     {
         "type": "inline",
-        "contents": "cb52e3aa68e61e4c508e34058440aefca8dd592d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz\", \"integrity\": \"sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==\", \"time\": 0, \"size\": 13091, \"metadata\": {\"url\": \"https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a2944c7d4f83b20b9bef9af9981c3bfebc1bcc11eca4644719e32f17189e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/14"
-    },
-    {
-        "type": "inline",
         "contents": "cb5911fb23f99721045060d65e103bdd208acec5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz\", \"integrity\": \"sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==\", \"time\": 0, \"size\": 2243, \"metadata\": {\"url\": \"https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "426a4d7d4174eab209a24fb69e54b905b138e58f5c676c01488c2ca08b53",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d8/51"
@@ -5008,21 +5318,15 @@
     },
     {
         "type": "inline",
-        "contents": "cd1b95c4baae08486edf0831f69eab8235748070\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.22.10.tgz\", \"integrity\": \"sha512-05WLmeV5M+P/0FS+bWf13hMew2X0oa8w9AtmevL2UyA/5GqiyvP2Xm5WfGQ8oFiiMvpnL6RFomJQOZtWca0C2w==\", \"time\": 0, \"size\": 4032, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "88f2c265748c3605f5db414df677398a1b691f28519627d00e68da9c8c6d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/33"
-    },
-    {
-        "type": "inline",
         "contents": "cd9778c443eb202955f61afde92f0297963d8fcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz\", \"integrity\": \"sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==\", \"time\": 0, \"size\": 2041, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c662626ec8eafafa54476678b9f71799a74ee368f2b7845a6ec9f9174a4d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/1f"
     },
     {
         "type": "inline",
-        "contents": "ceeaca15e0ec09d8fcc205af7ca49cbb2ec124e4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.10.tgz\", \"integrity\": \"sha512-ixomxVcnAONXDgaq0opvAx4UAOiEhOA/tipuhFFOvPKFd4yf1BAnEviB5maB0SBHHkJXPUSzDp/73xVTMGSe7g==\", \"time\": 0, \"size\": 31524, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f5a7dff7346850b4e671d09fff03db02f337adad97c53f790b30712b5b30",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/55"
+        "contents": "cda972f0ad949ded262680492c3c8f3b9ea5674d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz\", \"integrity\": \"sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==\", \"time\": 0, \"size\": 2893, \"metadata\": {\"url\": \"https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5dbe4fe773e1725ef1db02b7ca11131540cf36409388d4f6b0c0cb2bf773",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/9b"
     },
     {
         "type": "inline",
@@ -5044,9 +5348,9 @@
     },
     {
         "type": "inline",
-        "contents": "d04f7e58a54fc6babf6145cce3ec265b4932348d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.10.tgz\", \"integrity\": \"sha512-eeFX8dnRyf3LAdsdXWKWuN18hLRg8zy1cP0cP9rHzQVWRK7ck/QsLxK1vHq7MADGwQalNaNTJ9SQxH6c8mz6jw==\", \"time\": 0, \"size\": 10706, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ec5851b61562928be4b7ff392063d86c7ab95baa7552c572037032e3b182",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3e/90"
+        "contents": "d04bf98c4456aeda2a0b458ee15e7b791a21335e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz\", \"integrity\": \"sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==\", \"time\": 0, \"size\": 8913, \"metadata\": {\"url\": \"https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3823be4be0216c6b586c2eeec514837e4811d9f2cf65ab1e5bda679f7fdf",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/35"
     },
     {
         "type": "inline",
@@ -5056,9 +5360,21 @@
     },
     {
         "type": "inline",
+        "contents": "d16bfd46a9732e240cd0a1a30acfd851c849eb8c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz\", \"integrity\": \"sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==\", \"time\": 0, \"size\": 8892, \"metadata\": {\"url\": \"https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9ebd19a6213f232bd53cd84514e708af0e39cca030317ba3faae86ed4fc4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/b7"
+    },
+    {
+        "type": "inline",
         "contents": "d187aa8505f15feb18a64047d6f0e9e47907b135\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz\", \"integrity\": \"sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==\", \"time\": 0, \"size\": 5816, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "1ac061a165d332a3453489dd22e7fc413f9598bcab00b2181d7385fcb606",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/45"
+    },
+    {
+        "type": "inline",
+        "contents": "d191b466451a9ea0a1e32dafd49dd9900544e653\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.22.12.tgz\", \"integrity\": \"sha512-4x5GrQr1a/9L0paBC/MZZJjjgjxLYrqSmWd+e+QfAEPvmRxdRoQ5uKEuNgXnm9/weHQBTnQBQsOY2iFja+XGAw==\", \"time\": 0, \"size\": 577072, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6dc4d603458585eae36d1fd4bcbecc2db5363e91bfcab791af8bcb29b17a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/a5"
     },
     {
         "type": "inline",
@@ -5068,21 +5384,27 @@
     },
     {
         "type": "inline",
+        "contents": "d329188f2ccc43a1101aedc33ed86725afbabe73\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz\", \"integrity\": \"sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==\", \"time\": 0, \"size\": 691898, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4e639800aba61cb3b89a80eda65284ed2ff59faba53b0454b765632e9440",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/4e"
+    },
+    {
+        "type": "inline",
+        "contents": "d386b37ff6d6d9e501320b7c369617af38919b72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.22.12.tgz\", \"integrity\": \"sha512-FX8mTJuCt7/3zXVoeD/qHlm4YH2bVqBuWQHXSuBK054e7wFRnRnbSLPUqAwSeYP3lWqpuQzJtgiiBxV3+WWwTg==\", \"time\": 0, \"size\": 5864, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1466c7fbb85a4e9cbe33a8156d529b1cc54f891c48c5f502d7aae42f9084",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/f0"
+    },
+    {
+        "type": "inline",
         "contents": "d49713432e45ebd6c243ee0f28b05bee2cf8be75\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/global/-/global-4.4.0.tgz\", \"integrity\": \"sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==\", \"time\": 0, \"size\": 1896, \"metadata\": {\"url\": \"https://registry.npmjs.org/global/-/global-4.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e9ee6633118f0b2883227bfec1ccb66f0844b7a6816e4ac984def30c66d6",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/8e"
     },
     {
         "type": "inline",
-        "contents": "d56d47f3bbd9ea2d03103878f9b42f0c8709b7d2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz\", \"integrity\": \"sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==\", \"time\": 0, \"size\": 4498, \"metadata\": {\"url\": \"https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b9b6403ffa1311721576acca26c7d90a4822f1cbd8f17ebf30c4e99ecf3a",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/9d"
-    },
-    {
-        "type": "inline",
-        "contents": "d6276e6deb3688215e5b3ae232a5198c21cf9095\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.22.10.tgz\", \"integrity\": \"sha512-mhcwTO1ywRxiCgtLGge6tDDIDPlX6qkI3CY+BjgGG/XhVHccCddXgOGLdlf+5OuKIEF2Nqs0V01LQEQIJFTmEw==\", \"time\": 0, \"size\": 5448, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "af676d2f5c794ab295a09fe6a6f320a1c0f2b3edf0faaa9b0d3dba43f9a9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/eb/89"
+        "contents": "d52439f6fec2b3ac526894b4d1b3c038f260f649\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.22.12.tgz\", \"integrity\": \"sha512-N+6rwxdB+7OCR6PYijaA/iizXXodpxOGvT/smd/lxeXsZ/empHmFFFJ/FaXcYh19Tm04dGDaXcNF/dN5nm6+xQ==\", \"time\": 0, \"size\": 3497, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fa076088955fa35c19ce8a1776b9d7be919e4b1c742b0b32dd26b36160ca",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/8c"
     },
     {
         "type": "inline",
@@ -5104,15 +5426,15 @@
     },
     {
         "type": "inline",
-        "contents": "d879978b41161ee956b6ba11a3fd38f48ccaa15a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz\", \"integrity\": \"sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==\", \"time\": 0, \"size\": 4239, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6532bc014331c9b572482a4bd805bf54a7ff8b4ca179b1c811aff3dec690",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/ff"
+        "contents": "d86d2f242d790686125a49f820b9d37f1221a978\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz\", \"integrity\": \"sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==\", \"time\": 0, \"size\": 11144, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "312da97f30066c83d700e4b7105e570951a5222da82d36f48070511ddb45",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/98"
     },
     {
         "type": "inline",
-        "contents": "d95b92451f69c44b96c728e67314ebb122c209c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/types/-/types-0.22.10.tgz\", \"integrity\": \"sha512-u/r+XYzbCx4zZukDmxx8S0er3Yq3iDPI6+31WKX0N18i2qPPJYcn8qwIFurfupRumGvJ8SlGLCgt/T+Y8zzUIw==\", \"time\": 0, \"size\": 3411, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/types/-/types-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2888ab1427aa902a7ece9b16dd4476f3992aae53414fe6c874c21b6722cd",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/61"
+        "contents": "d879978b41161ee956b6ba11a3fd38f48ccaa15a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz\", \"integrity\": \"sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==\", \"time\": 0, \"size\": 4239, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6532bc014331c9b572482a4bd805bf54a7ff8b4ca179b1c811aff3dec690",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/ff"
     },
     {
         "type": "inline",
@@ -5122,21 +5444,9 @@
     },
     {
         "type": "inline",
-        "contents": "dab28eafa40faa4b82eacadb3e8c417f3101e55c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz\", \"integrity\": \"sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==\", \"time\": 0, \"size\": 3777, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "7e3a3b6f66b8ad6e21a2d5fe2c272f8e8acab087081bacb99e732361f262",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8a/d8"
-    },
-    {
-        "type": "inline",
-        "contents": "dc43abff2f61eb4eb4e3ffca912a5fec29f3a4e1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globals/-/globals-13.23.0.tgz\", \"integrity\": \"sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==\", \"time\": 0, \"size\": 9623, \"metadata\": {\"url\": \"https://registry.npmjs.org/globals/-/globals-13.23.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "e98a4278642c153cd7333d9f67b607e15cc44107950a0b82c58319b3d91a",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/e9"
-    },
-    {
-        "type": "inline",
-        "contents": "dc5ac7a1f37dd234823b4ac1e2ec0b948d7c5c4e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron/-/electron-28.1.0.tgz\", \"integrity\": \"sha512-82Y7o4PSWPn1o/aVwYPsgmBw6Gyf2lVHpaBu3Ef8LrLWXxytg7ZRZr/RtDqEMOzQp3+mcuy3huH84MyjdmP50Q==\", \"time\": 0, \"size\": 153156, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron/-/electron-28.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2c535b75f96943bdcdc7f0da78901817077406a7ee728d0a8fff91430277",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/73"
+        "contents": "dba2254015c01091fada8ce722a48186eb518774\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz\", \"integrity\": \"sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==\", \"time\": 0, \"size\": 95594, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9d5b56cb41c148496f28629d870d69b182ea4183643a89c26c61a083d65e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4d/b8"
     },
     {
         "type": "inline",
@@ -5155,6 +5465,12 @@
         "contents": "dcf769524365383f6df36d778ead11e29045e495\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz\", \"integrity\": \"sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==\", \"time\": 0, \"size\": 1949, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5573a63509099c8f965cee0e85671d503d30fbc6e8cef78a3de92574677d",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/68"
+    },
+    {
+        "type": "inline",
+        "contents": "dd5f01f087b3dc16795abaf98f11a73369d572d6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.12.tgz\", \"integrity\": \"sha512-S0vJADTuh1Q9F+cXAwFPlrKWzDj2F9t/9JAbUvaaDuivpyWuImEKXVz5PUZw2NbpuSHjwssbTpOZ8F13iJX4uw==\", \"time\": 0, \"size\": 8766, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d35e81f6e99d9e2170599835e6ac6bceb2f78c09320309b2eca79342630c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/c4"
     },
     {
         "type": "inline",
@@ -5179,6 +5495,12 @@
         "contents": "de605db01a4859a2780358a4a9ebe507ab934fb8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz\", \"integrity\": \"sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==\", \"time\": 0, \"size\": 4326, \"metadata\": {\"url\": \"https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2795c6c0e28ed5e20a2b282ba1d57eacb9d26a3ab711b97cf7921532d66e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/cf"
+    },
+    {
+        "type": "inline",
+        "contents": "dee89e01939d3203766ff150a556cdaf32ac8213\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz\", \"integrity\": \"sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==\", \"time\": 0, \"size\": 4174, \"metadata\": {\"url\": \"https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0225ebc4f465d0a696cfa2f9a35c3b588a7fd6abc54dabf6ed3dd8404b10",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/08"
     },
     {
         "type": "inline",
@@ -5212,33 +5534,15 @@
     },
     {
         "type": "inline",
-        "contents": "e233227752d9b40b5d63794982d199f39f90bbf0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/custom/-/custom-0.22.10.tgz\", \"integrity\": \"sha512-sPZkUYe1hu0iIgNisjizxPJqq2vaaKvkCkPoXq2U6UV3ZA1si/WVdrg25da3IcGIEV+83AoHgM8TvqlLgrCJsg==\", \"time\": 0, \"size\": 8661, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/custom/-/custom-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "9d5577bc4e34df32257e2f09a342b31f9ab58e85892a3a87929cf79e0016",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/70"
-    },
-    {
-        "type": "inline",
         "contents": "e2690a8a515c19e0b5586c8d753b292545e70c5a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz\", \"integrity\": \"sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==\", \"time\": 0, \"size\": 1576, \"metadata\": {\"url\": \"https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e55f7dee732afb485929a6dddd2838e0820731ce64024421d02044a30bd2",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/b3"
     },
     {
         "type": "inline",
-        "contents": "e2d6e9571b47be457126d1a4985cb318d169cef0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz\", \"integrity\": \"sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==\", \"time\": 0, \"size\": 15429, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b4301addf3aa14f8df7ded90e44bb99994aad16567692a4e9d5220b6dacc",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/2c"
-    },
-    {
-        "type": "inline",
         "contents": "e34c459e8fb297f03e7e758ee4c3898b739a6516\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz\", \"integrity\": \"sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==\", \"time\": 0, \"size\": 7449, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "98f7c0963a2f79f6ed59f860bce88d15cf7d179d479ca6deff94c70e4d26",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/21"
-    },
-    {
-        "type": "inline",
-        "contents": "e3c2472644e5df586e7d20af93532cbda900815d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.10.tgz\", \"integrity\": \"sha512-4XRTWuPVdMXJeclJMisXPGizeHtTryVaVV5HnuQXpKqIZtzXReCCpNGH8q/i0kBQOQMXhGWS3mpqOEwtpPePKw==\", \"time\": 0, \"size\": 8768, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "d24a60060295e0ddbd2e8d7e0cb95ba1e98c3e8e6c78da43d0d6895781bd",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/43"
     },
     {
         "type": "inline",
@@ -5272,12 +5576,6 @@
     },
     {
         "type": "inline",
-        "contents": "e5a01e4c0fe3f0c23edaff6114a90bdb34f2620e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz\", \"integrity\": \"sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==\", \"time\": 0, \"size\": 7244, \"metadata\": {\"url\": \"https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "978d192563d31d1902778d74d109a4772284c172af78bd0ff26c7d6d3198",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/43"
-    },
-    {
-        "type": "inline",
         "contents": "e5c8d688b6f4deb438d53af0e0f8186131929506\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz\", \"integrity\": \"sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==\", \"time\": 0, \"size\": 2246, \"metadata\": {\"url\": \"https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "8e7e8934679b7b49b8240b1f2dcb66c25a5bd17f9629f8fe0ea634cab93c",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/6f"
@@ -5290,33 +5588,9 @@
     },
     {
         "type": "inline",
-        "contents": "e63d41319227e07c8d8724ede6ca714e79dd8b68\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.10.tgz\", \"integrity\": \"sha512-6bu98pAcVN4DY2oiDLC4TOgieX/lZrLd1tombWZOFCN5PBmqaHQxm7IUmT+Wj4faEvh8QSHgVLSA+2JQQRJWVA==\", \"time\": 0, \"size\": 152219, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2852302ea08fd20227d10742dbbe9a2d09c0d252f9bf17ecb5449ad9cf09",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/89"
-    },
-    {
-        "type": "inline",
-        "contents": "e74f9c098ce4aa673d36d750dabd3738b7ea07f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.22.10.tgz\", \"integrity\": \"sha512-ykrG/6lTp9Q5YA8jS5XzwMHtRxb9HOFMgtmnrUZ8kU+BK8REecfy9Ic5BUEOjCYvS1a/xLsnrZQU07iiYxBxFg==\", \"time\": 0, \"size\": 5013, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8357ab006d7a1b5236075625fe999897160b65c88575d80536b7a6ab8bfc",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/16/15"
-    },
-    {
-        "type": "inline",
-        "contents": "e8760bb3bf8d7dba07e7cceb7175213078440ac1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.22.10.tgz\", \"integrity\": \"sha512-llNiWWMTKISDXt5+cXI0GaFmZWAjlT+4fFLYf4eXquuL/9wZoQsEBhv2GdGd48mkiS8jZq1Nnb2Q4ehEPTvrzw==\", \"time\": 0, \"size\": 4180, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "9f6955b0ae2b5da2484edd144df90e48c8647a514db850d350e9ec2f14a5",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/91"
-    },
-    {
-        "type": "inline",
         "contents": "e89469a6811ed222fc3dba0c7639b107c75cac58\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz\", \"integrity\": \"sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==\", \"time\": 0, \"size\": 66869, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "290780d825bbfd32d6d7f239f3ec70ed141557a5676440bd01fa771e865a",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b8/b1"
-    },
-    {
-        "type": "inline",
-        "contents": "e8c33885874fb79b6dc2be89acd49525330f0d5b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/gif/-/gif-0.22.10.tgz\", \"integrity\": \"sha512-yEX2dSpamvkSx1PPDWGnKeWDrBz0vrCKjVG/cn4Zr68MRRT75tbZIeOrBa+RiUpY3ho5ix7d36LkYvt3qfUIhQ==\", \"time\": 0, \"size\": 140561, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/gif/-/gif-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1f4685bb56026d7a0f0ce21810be550b5af74087f4acdccc6471cb3af0f3",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/e0"
     },
     {
         "type": "inline",
@@ -5332,6 +5606,12 @@
     },
     {
         "type": "inline",
+        "contents": "ea2ed1bfa310aba18b37f333ecb6319874903fe4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz\", \"integrity\": \"sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==\", \"time\": 0, \"size\": 12500, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a085eb4e0aa967da47d9ce434951945778bef724061b3deca750246c0d8e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/03"
+    },
+    {
+        "type": "inline",
         "contents": "eb16598c80e946907ebe0fdffdb9123f2ad28b49\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz\", \"integrity\": \"sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==\", \"time\": 0, \"size\": 11670, \"metadata\": {\"url\": \"https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "3105b066c2c6aa6572229d813ca25955229e067ee026bac572fae6db2e57",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/8c"
@@ -5341,6 +5621,12 @@
         "contents": "eb55e357db5ffa3616b9f331bb2b01cd24a60d41\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz\", \"integrity\": \"sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==\", \"time\": 0, \"size\": 1676, \"metadata\": {\"url\": \"https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "532a4c7bf52c908d567ded2bb11b0f3282f0733d0d079a5291c2f72e0077",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/fd"
+    },
+    {
+        "type": "inline",
+        "contents": "eb62dceaf1f747732f92408354a5a0f8f4f9c944\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/glob/-/glob-10.3.10.tgz\", \"integrity\": \"sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==\", \"time\": 0, \"size\": 68437, \"metadata\": {\"url\": \"https://registry.npmjs.org/glob/-/glob-10.3.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5508fd666b07544d36130b550b5430968831ea5b18f3e98baf502fb7507e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/e9"
     },
     {
         "type": "inline",
@@ -5362,27 +5648,15 @@
     },
     {
         "type": "inline",
-        "contents": "ed2d249025a1283066281e3e6d1d16cd486a169a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jimp/-/jimp-0.22.10.tgz\", \"integrity\": \"sha512-lCaHIJAgTOsplyJzC1w/laxSxrbSsEBw4byKwXgUdMmh+ayPsnidTblenQm+IvhIs44Gcuvlb6pd2LQ0wcKaKg==\", \"time\": 0, \"size\": 2212445, \"metadata\": {\"url\": \"https://registry.npmjs.org/jimp/-/jimp-0.22.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ab78ae49722dadc7f4aff18bcc79b4eb7711d688c267bf28517dc5a87371",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/91/4f"
-    },
-    {
-        "type": "inline",
-        "contents": "ed57a428d1336127a166815625a99f0754dfd10d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz\", \"integrity\": \"sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==\", \"time\": 0, \"size\": 13498, \"metadata\": {\"url\": \"https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ea27bf5367eced383b8190e1a6e8b30ed2cfa9c36943033912ee2110687f",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/a8"
-    },
-    {
-        "type": "inline",
-        "contents": "edab2c4de449f17ba407662c6741d9faf93fa0cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.0.tgz\", \"integrity\": \"sha512-zfA+5SuwYN2VWqN1/5HZaDzQKLJHaBVMZIIM+wuYjdptkaQsqzDdqjqf+lZZJUuJq1aanHiY8LhH8LmH+qBYJA==\", \"time\": 0, \"size\": 9216, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1d10a8a3d7490de59b683163cb509a468ceed4ed0a624aebe7f837ec135c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/32"
-    },
-    {
-        "type": "inline",
         "contents": "ee88913f76915af25e64aca1fc488d82b849056b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz\", \"integrity\": \"sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==\", \"time\": 0, \"size\": 2039, \"metadata\": {\"url\": \"https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6179aff4f4b91a00b02f4ca53b423cd3ece0add9a11a64f5e022c5e88bae",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/73"
+    },
+    {
+        "type": "inline",
+        "contents": "efe0156e1149f39e05fb4da76a91fb91419d9e35\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz\", \"integrity\": \"sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==\", \"time\": 0, \"size\": 6089, \"metadata\": {\"url\": \"https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1a8a24c5a8be9404619dfc8a0db85cb35d97a7d3f23cfc16f3c8f5d083c7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/2f"
     },
     {
         "type": "inline",
@@ -5416,15 +5690,15 @@
     },
     {
         "type": "inline",
-        "contents": "f3f03109b1f1af958faf46f49dc558cfcef39521\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz\", \"integrity\": \"sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==\", \"time\": 0, \"size\": 5054087, \"metadata\": {\"url\": \"https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "12a114508493f926726e785ecde958160a040c681761987ad0d06e40e1b6",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/88"
+        "contents": "f2df7775bf8aa3e23aa1fa6986b2d6fc9106c561\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz\", \"integrity\": \"sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==\", \"time\": 0, \"size\": 8661, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3925715fd1908adf334ecf030a51a2726312a572556b176909ff3a686cf3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/a9"
     },
     {
         "type": "inline",
-        "contents": "f3f9eedf785bda3846544b1f29a9ed07d67fb8c6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz\", \"integrity\": \"sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==\", \"time\": 0, \"size\": 4312, \"metadata\": {\"url\": \"https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1929926becc54c1f69c0921ab74c461c1777ab3d43213900acd4779dbf27",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/34"
+        "contents": "f3f03109b1f1af958faf46f49dc558cfcef39521\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz\", \"integrity\": \"sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==\", \"time\": 0, \"size\": 5054087, \"metadata\": {\"url\": \"https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "12a114508493f926726e785ecde958160a040c681761987ad0d06e40e1b6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/88"
     },
     {
         "type": "inline",
@@ -5470,6 +5744,12 @@
     },
     {
         "type": "inline",
+        "contents": "faeec0561e2980b6428a70bbfe2d9778849d643e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz\", \"integrity\": \"sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==\", \"time\": 0, \"size\": 48103, \"metadata\": {\"url\": \"https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "034e74fce56a25a123ccc68311a73614ab35752a83a669418d1a3b5ea97e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dc/ab"
+    },
+    {
+        "type": "inline",
         "contents": "fb1be7f69d4ecf636c0348cbebd02d75a02b5d24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz\", \"integrity\": \"sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==\", \"time\": 0, \"size\": 2765, \"metadata\": {\"url\": \"https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2ace9a1dfbea06eafdda3044e21e830e5cbd76a5eb5a794acdc111e0c31e",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/cb/f4"
@@ -5485,6 +5765,12 @@
         "contents": "fbfdd095413cc9fa6bb3b8400b241115b4a4b438\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.defaultto/-/lodash.defaultto-4.14.0.tgz\", \"integrity\": \"sha512-G6tizqH6rg4P5j32Wy4Z3ZIip7OfG8YWWlPFzUFGcYStH1Ld0l1tWs6NevEQNEDnO1M3NZYjuHuraaFSN5WqeQ==\", \"time\": 0, \"size\": 2197, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.defaultto/-/lodash.defaultto-4.14.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "e484268a8b6717b0ab3a50cfe3611c0f9d9dc29195ec3ef68704b080cddb",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/21"
+    },
+    {
+        "type": "inline",
+        "contents": "fc048f58e4ee85654ce97321374c1d063e07005c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz\", \"integrity\": \"sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==\", \"time\": 0, \"size\": 10901, \"metadata\": {\"url\": \"https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e9b74e6134396bc3c41a6db204cb4fc9057d040c5e03fb803d1725616e2f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/17"
     },
     {
         "type": "inline",
@@ -5523,10 +5809,10 @@
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/62"
     },
     {
-        "type": "script",
-        "commands": [],
-        "dest-filename": "patch.sh",
-        "dest": "flatpak-node"
+        "type": "inline",
+        "contents": "ff707d6ac104c118d9c9b38cb1be3640d43dc950\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-publish/-/electron-publish-24.9.4.tgz\", \"integrity\": \"sha512-FghbeVMfxHneHjsG2xUSC0NMZYWOOWhBxfZKPTbibcJ0CjPH0Ph8yb5CUO62nqywXfA5u1Otq6K8eOdOixxmNg==\", \"time\": 0, \"size\": 20047, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-publish/-/electron-publish-24.9.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6e586c214c8b7ef9834e7923b1c8ac03f4ad36ef9ce928d2111ada43b1d7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/73"
     },
     {
         "type": "script",
@@ -5560,6 +5846,15 @@
     {
         "type": "script",
         "commands": [
+            "jq --arg buildroot \"$FLATPAK_BUILDER_BUILDDIR\" --argjson data '{\"github:devsnek/node-register-scheme#e7cc9a63a1f512565da44cb57316d9fb10750e17\": \"flatpak-node/git-packages/register-scheme-e7cc9a63a1f512565da44cb57316d9fb10750e17#e7cc9a63a1f512565da44cb57316d9fb10750e17\", \"github:devsnek/node-register-scheme\": \"flatpak-node/git-packages/register-scheme-e7cc9a63a1f512565da44cb57316d9fb10750e17#e7cc9a63a1f512565da44cb57316d9fb10750e17\", \"git+ssh://git@github.com:devsnek/node-register-scheme.git#e7cc9a63a1f512565da44cb57316d9fb10750e17\": \"flatpak-node/git-packages/register-scheme-e7cc9a63a1f512565da44cb57316d9fb10750e17#e7cc9a63a1f512565da44cb57316d9fb10750e17\", \"git+ssh://git@github.com:devsnek/node-register-scheme.git\": \"flatpak-node/git-packages/register-scheme-e7cc9a63a1f512565da44cb57316d9fb10750e17#e7cc9a63a1f512565da44cb57316d9fb10750e17\"}' 'walk(    if type == \"object\"    then        to_entries | map(            if (.value | type == \"string\") and $data[.value]            then .value = \"git+file:\\($buildroot)/\\($data[.value])\"            else .            end        ) | from_entries    else .    end)' $FLATPAK_BUILDER_BUILDDIR/package.json > $FLATPAK_BUILDER_BUILDDIR/package.json.new",
+            "mv $FLATPAK_BUILDER_BUILDDIR/package.json{.new,}"
+        ],
+        "dest-filename": "patch.sh",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "script",
+        "commands": [
             "version=$(node --version | sed \"s/^v//\")",
             "nodedir=$(dirname \"$(dirname \"$(which node)\")\")",
             "mkdir -p \"flatpak-node/cache/node-gyp/$version\"",
@@ -5579,10 +5874,10 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-arm64.zip\"",
-            "ln -s \"../electron-v28.1.0-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-arm64.zip/electron-v28.1.0-linux-arm64.zip\"",
-            "mkdir -p \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0\"",
-            "ln -s \"../electron-v28.1.0-linux-arm64.zip\" \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0/electron-v28.1.0-linux-arm64.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv29.1.0electron-v29.1.0-linux-arm64.zip\"",
+            "ln -s \"../electron-v29.1.0-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv29.1.0electron-v29.1.0-linux-arm64.zip/electron-v29.1.0-linux-arm64.zip\"",
+            "mkdir -p \"3d6c1e329a1ffc710a5aba616c284f4d113398c0bbbb3ff758fcc20819a082f9\"",
+            "ln -s \"../electron-v29.1.0-linux-arm64.zip\" \"3d6c1e329a1ffc710a5aba616c284f4d113398c0bbbb3ff758fcc20819a082f9/electron-v29.1.0-linux-arm64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -5592,10 +5887,10 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-armv7l.zip\"",
-            "ln -s \"../electron-v28.1.0-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-armv7l.zip/electron-v28.1.0-linux-armv7l.zip\"",
-            "mkdir -p \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0\"",
-            "ln -s \"../electron-v28.1.0-linux-armv7l.zip\" \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0/electron-v28.1.0-linux-armv7l.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv29.1.0electron-v29.1.0-linux-armv7l.zip\"",
+            "ln -s \"../electron-v29.1.0-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv29.1.0electron-v29.1.0-linux-armv7l.zip/electron-v29.1.0-linux-armv7l.zip\"",
+            "mkdir -p \"3d6c1e329a1ffc710a5aba616c284f4d113398c0bbbb3ff758fcc20819a082f9\"",
+            "ln -s \"../electron-v29.1.0-linux-armv7l.zip\" \"3d6c1e329a1ffc710a5aba616c284f4d113398c0bbbb3ff758fcc20819a082f9/electron-v29.1.0-linux-armv7l.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -5605,10 +5900,10 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-x64.zip\"",
-            "ln -s \"../electron-v28.1.0-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv28.1.0electron-v28.1.0-linux-x64.zip/electron-v28.1.0-linux-x64.zip\"",
-            "mkdir -p \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0\"",
-            "ln -s \"../electron-v28.1.0-linux-x64.zip\" \"ddb00ab81d1a92fc0ebdbfd951e5c998dd5156b88b5dfa420d8032d922234db0/electron-v28.1.0-linux-x64.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv29.1.0electron-v29.1.0-linux-x64.zip\"",
+            "ln -s \"../electron-v29.1.0-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv29.1.0electron-v29.1.0-linux-x64.zip/electron-v29.1.0-linux-x64.zip\"",
+            "mkdir -p \"3d6c1e329a1ffc710a5aba616c284f4d113398c0bbbb3ff758fcc20819a082f9\"",
+            "ln -s \"../electron-v29.1.0-linux-x64.zip\" \"3d6c1e329a1ffc710a5aba616c284f4d113398c0bbbb3ff758fcc20819a082f9/electron-v29.1.0-linux-x64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [

--- a/info.beyondallreason.bar.appdata.xml
+++ b/info.beyondallreason.bar.appdata.xml
@@ -98,6 +98,12 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="1.2988.0.0" date="2024-03-02">
+            <description>
+                <p>New stable release of the game launcher.</p>
+            </description>
+            <url>https://github.com/beyond-all-reason/BYAR-Chobby/releases/tag/v1.2988.0</url>
+        </release>
         <release version="1.2838.0.0" date="2024-01-04">
             <description>
                 <p>New stable release of the game launcher.</p>

--- a/info.beyondallreason.bar.desktop
+++ b/info.beyondallreason.bar.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Beyond All Reason
-Exec=launcher-args.sh
+Exec=run.sh
 Comment=The Total Annihilation Inspired RTS you've been waiting for
 Type=Application
 Icon=info.beyondallreason.bar

--- a/info.beyondallreason.bar.metainfo.xml
+++ b/info.beyondallreason.bar.metainfo.xml
@@ -1,10 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
     <id>info.beyondallreason.bar</id>
     <name>Beyond All Reason</name>
-    <summary>The Total Annihilation Inspired RTS you've been waiting for</summary>
+    <summary>Total Annihilation Inspired RTS</summary>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-2.0-or-later</project_license>
+    <launchable type="desktop-id">info.beyondallreason.bar.desktop</launchable>
+    <content_rating type="oars-1.1">
+        <content_attribute id="violence-cartoon">moderate</content_attribute>
+        <content_attribute id="violence-fantasy">moderate</content_attribute>
+        <content_attribute id="social-chat">intense</content_attribute>
+    </content_rating>
+    <developer id="info.beyondallreason">
+        <name>BAR Team</name>
+    </developer>
+    <url type="homepage">https://www.beyondallreason.info</url>
+    <url type="bugtracker">https://github.com/beyond-all-reason/Beyond-All-Reason/issues</url>
+    <url type="donation">https://www.beyondallreason.info/donate-for-bar</url>
+    <url type="faq">https://www.beyondallreason.info/faq</url>
+    <recommends>
+        <internet>always</internet>
+        <memory>12288</memory>
+    </recommends>
+    <categories>
+        <category>Game</category>
+    </categories>
+    <branding>
+        <color type="primary" scheme_preference="light">#e0e0e0</color>
+        <color type="primary" scheme_preference="dark">#282828</color>
+    </branding>
+    <keywords>
+        <keyword>rts</keyword>
+        <keyword>real-time strategy</keyword>
+    </keywords>
     <description>
         <p>3D Real-Time Strategy Redefined. The Total Annihilation Inspired RTS you've been waiting for.</p>
 
@@ -31,10 +59,6 @@
         <p>400+ Units Unique and with a Purpose:</p>
         <p>Each and every unit in the game has a role to fill. Mix-and-match units to create infinite possible tactics. Experiment with your own combinations and show off the new strategies you develop in battle.</p>
     </description>
-    <developer_name>BAR Team</developer_name>
-    <url type="homepage">https://www.beyondallreason.info</url>
-    <url type="bugtracker">https://github.com/beyond-all-reason/Beyond-All-Reason/issues</url>
-    <url type="donation">https://www.beyondallreason.info/donate-for-bar</url>
     <screenshots>
         <screenshot type="default">
             <image>https://raw.githubusercontent.com/flathub/info.beyondallreason.bar/master/screenshot/screenshot_01.jpg</image>
@@ -278,9 +302,4 @@
             </description>
         </release>
     </releases>
-    <content_rating type="oars-1.1">
-        <content_attribute id="violence-cartoon">moderate</content_attribute>
-        <content_attribute id="violence-fantasy">moderate</content_attribute>
-        <content_attribute id="social-chat">intense</content_attribute>
-    </content_rating>
 </component>

--- a/info.beyondallreason.bar.yml
+++ b/info.beyondallreason.bar.yml
@@ -99,7 +99,7 @@ modules:
         install -Dm755 -t /app/bin/ run.sh
         install -Dm644 /app/chobby/dist_cfg/build/icon.png /app/share/icons/hicolor/128x128/apps/info.beyondallreason.bar.png
         install -Dm644 info.beyondallreason.bar.desktop /app/share/applications/info.beyondallreason.bar.desktop
-        install -Dm644 info.beyondallreason.bar.appdata.xml /app/share/metainfo/info.beyondallreason.bar.appdata.xml
+        install -Dm644 info.beyondallreason.bar.metainfo.xml /app/share/metainfo/info.beyondallreason.bar.metainfo.xml
       # Copy addr2line to bin so that engine can execute it to generate stacktrace
       - |
         cp /usr/bin/addr2line /app/bin
@@ -109,6 +109,6 @@ modules:
       - type: file
         path: info.beyondallreason.bar.desktop
       - type: file
-        path: info.beyondallreason.bar.appdata.xml
+        path: info.beyondallreason.bar.metainfo.xml
       - type: file
         path: run.sh

--- a/info.beyondallreason.bar.yml
+++ b/info.beyondallreason.bar.yml
@@ -4,15 +4,15 @@ runtime-version: "23.08"
 base: org.electronjs.Electron2.BaseApp
 base-version: "23.08"
 sdk: org.freedesktop.Sdk
-command: launcher-args.sh
+command: run.sh
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node18
+  - org.freedesktop.Sdk.Extension.node20
 build-options:
-  append_path: "/usr/lib/sdk/node18/bin"
+  append_path: "/usr/lib/sdk/node20/bin"
   cflags: -O2 -g
   cxxflags: -O2 -g
   env:
-    npm_config_nodedir: /usr/lib/sdk/node18
+    npm_config_nodedir: /usr/lib/sdk/node20
     npm_config_offline: 'true'
     NPM_CONFIG_LOGLEVEL: info
     XDG_CACHE_HOME: /run/build/spring-launcher/flatpak-node/cache
@@ -24,81 +24,91 @@ finish-args:
   - --socket=pulseaudio
   - --device=dri
   - --share=network
-  - --env=PATH=/usr/bin:/app/bin:/usr/lib/sdk/node18/bin
+  - --env=PATH=/usr/bin:/app/bin:/usr/lib/sdk/node20/bin
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
+cleanup:
+  - '/chobby'
 modules:
+  - name: chobby
+    buildsystem: simple
+    build-commands:
+    sources:
+      - type: git
+        url: https://github.com/beyond-all-reason/BYAR-Chobby
+        commit: eece9ffed260ff110ec2cc31fac25c4daf7a9c51
+        # We do full clone to make sure PACKAGE_VERSION is computed correctly.
+        disable-shallow-clone: true
+    build-commands:
+      - |
+        mkdir -p /app/chobby
+        echo "1.$(git rev-list --count HEAD).0" > /app/chobby/PACKAGE_VERSION
+        cp -r dist_cfg /app/chobby
+        cp -r build /app/chobby
   - name: spring-launcher
     buildsystem: simple
     build-commands:
       # First steps from https://github.com/beyond-all-reason/BYAR-Chobby/blob/master/.github/workflows/launcher.yml
       # GitHub Action step: Patch launcher with dist_cfg
       - |
-        cp -r BYAR-Chobby/dist_cfg/* launcher/src/
+        cp -r /app/chobby/dist_cfg/* src/
         for dir in bin files build; do
-          mkdir -p launcher/$dir
-          if [ -d launcher/src/$dir/ ]; then
-            mv launcher/src/$dir/* launcher/$dir/
-            rm -rf launcher/src/$dir
+          mkdir -p $dir
+          if [ -d src/$dir/ ]; then
+            mv src/$dir/* $dir/
+            rm -rf src/$dir
           fi
         done
       # GitHub Action step: Make package.json
       - |
-        cd BYAR-Chobby
-        export PACKAGE_VERSION=1.$(git rev-list --count HEAD).0
+        export PACKAGE_VERSION=$(cat /app/chobby/PACKAGE_VERSION)
         echo "Making build for version: $PACKAGE_VERSION"
-        node build/make_package_json.js ../launcher/package.json dist_cfg/config.json $GITHUB_REPOSITORY $PACKAGE_VERSION
+        node /app/chobby/build/make_package_json.js package.json /app/chobby/dist_cfg/config.json $GITHUB_REPOSITORY $PACKAGE_VERSION
 
       # For flatpak we don't want to build AppImage, but unpacked
       - |
-        cd launcher
         jq '.build.linux.target="dir"' <<<$(<package.json) > package.json
+        jq '.build.files+=["!flatpak-node/**"]' <<<$(<package.json) > package.json
         cat package.json
       # Install all packages, use `--ignore-scripts`, so electron does not make a postinstall request
       - |
-        cd launcher
-        npm ci --offline --ignore-scripts --cache=/run/build/spring-launcher/flatpak-node/npm-cache/
+        npm ci --ignore-scripts
       # Build electron app
       - |
         . flatpak-node/electron-builder-arch-args.sh
-        cd launcher
-        node_modules/.bin/electron-builder -- $ELECTRON_BUILDER_ARCH_ARGS --linux --dir --project /run/build/spring-launcher/launcher
+        node_modules/.bin/electron-builder -- $ELECTRON_BUILDER_ARCH_ARGS --linux --dir
       # Install application in destination folder
       - |
-        cp -a launcher/dist/linux*unpacked /app/main
-        install -Dm755 -t /app/bin/ launcher-args.sh
+        cp -a dist/linux*unpacked /app/main
+    sources:
+      - type: git
+        url: https://github.com/beyond-all-reason/spring-launcher
+        commit: 2c0a6e17b50ab04ea592c53963c571e5ccb071ba
+        # This generated-sources.json from npm generator *really* wants that source is in the top directory
+        # and not in some sub directory, that's why there is a bunch of complexity with moving files around etc
+      - generated-sources.json
+    build-options:
+      env:
+        XDG_CACHE_HOME: /run/build/spring-launcher/flatpak-node/cache
+        npm_config_cache: /run/build/spring-launcher/flatpak-node/npm-cache
+        npm_config_nodedir: /usr/lib/sdk/node20
+        npm_config_offline: 'true'
+  - name: main
+    buildsystem: simple
+    build-commands:
+      - |
         install -Dm755 -t /app/bin/ run.sh
-        install -Dm644 BYAR-Chobby/dist_cfg/build/icon.png /app/share/icons/hicolor/128x128/apps/info.beyondallreason.bar.png
+        install -Dm644 /app/chobby/dist_cfg/build/icon.png /app/share/icons/hicolor/128x128/apps/info.beyondallreason.bar.png
         install -Dm644 info.beyondallreason.bar.desktop /app/share/applications/info.beyondallreason.bar.desktop
         install -Dm644 info.beyondallreason.bar.appdata.xml /app/share/metainfo/info.beyondallreason.bar.appdata.xml
       # Copy addr2line to bin so that engine can execute it to generate stacktrace
       - |
         cp /usr/bin/addr2line /app/bin
-        cp /lib/x86_64-linux-gnu/libbfd-2.41.so /app/lib
-        cp /usr/lib/x86_64-linux-gnu/libsframe.so.1 /app/lib
+        cp /lib/x86_64-linux-gnu/libbfd* /app/lib
+        cp /usr/lib/x86_64-linux-gnu/libsframe* /app/lib
     sources:
-      - type: git
-        url: https://github.com/beyond-all-reason/BYAR-Chobby
-        commit: bbad0ab7c5ccbc207754449c47c65db4da436009
-        dest: BYAR-Chobby
-        # We do full clone to make sure PACKAGE_VERSION is computed correctly.
-        disable-shallow-clone: true
-      - type: git
-        url: https://github.com/beyond-all-reason/spring-launcher
-        commit: 6792caf2ede73f3f601a0ab7fbb4fb38c96fbb40
-        dest: launcher
       - type: file
         path: info.beyondallreason.bar.desktop
       - type: file
         path: info.beyondallreason.bar.appdata.xml
-      - generated-sources.json
       - type: file
-        path: launcher-args.sh
-      - type: script
-        dest-filename: run.sh
-        commands:
-          - zypak-wrapper.sh /app/main/beyond-all-reason "$@"
-    build-options:
-      env:
-        XDG_CACHE_HOME: /run/build/spring-launcher/flatpak-node/cache
-        npm_config_cache: /run/build/spring-launcher/flatpak-node/npm-cache
-        npm_config_nodedir: /usr/lib/sdk/node18
-        npm_config_offline: 'true'
+        path: run.sh

--- a/launcher-args.sh
+++ b/launcher-args.sh
@@ -1,1 +1,0 @@
-run.sh --disable-launcher-update -w $XDG_DATA_HOME "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+# https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)
+for i in {0..9}; do
+    test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+done
+
+zypak-wrapper.sh /app/main/beyond-all-reason --disable-launcher-update -w $XDG_DATA_HOME "$@"


### PR DESCRIPTION
As part of the update, I had to refactor quite a bit of how the build process works.

flatpak-node-generator is quite bugged:
 - Output `generated-source.json` expects the package to be in the main directory, so I've split the build into modules but still had to add `flatpak-node` exclusion to build
 - I had to patch locally https://github.com/flatpak/flatpak-builder-tools/pull/382 and use that because https://github.com/flatpak/flatpak-builder-tools/issues/381
 - I've also run into https://github.com/flatpak/flatpak-builder-tools/issues/377

I've also:
 - Made copying of addr2line dependencies more reliable
 - Merged the startup scripts into one
 - Added permission and setup for discord so that rich presence works