### PR TITLE
fix bwrap: execvp run.sh: Exec format error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)
 for i in {0..9}; do
     test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;


### PR DESCRIPTION
Running the flatpak on Alpine linux creates the following error:

bwrap: execvp run.sh: Exec format error (see #4647 in https://github.com/beyond-all-reason/Beyond-All-Reason/issues/4647). This PR fixes that issue by adding a shebang.