### PR TITLE
Add Wayland support

### DIFF
--- a/info.beyondallreason.bar.yml
+++ b/info.beyondallreason.bar.yml
@@ -21,6 +21,7 @@ build-options:
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
   - --share=network


### PR DESCRIPTION
BAR itself can use Wayland, only the launcher needs X11.